### PR TITLE
Hotfix/issue saga 451

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ def get_version (mod_root):
         sdist_name = sdist_name.replace ('/', '-')
         sdist_name = sdist_name.replace ('@', '-')
         sdist_name = sdist_name.replace ('#', '-')
+        sdist_name = sdist_name.replace ('_', '-')
         if '--record'  in sys.argv or 'bdist_egg' in sys.argv :   
            # pip install stage 2      easy_install stage 1
            # NOTE: pip install will untar the sdist in a tmp tree.  In that tmp

--- a/src/radical/utils/lease_manager.py
+++ b/src/radical/utils/lease_manager.py
@@ -281,6 +281,12 @@ class LeaseManager (object) :
             # no unlocked object found -- create a new one 
             obj = self._create_object (pool_id, creator, args)
 
+            # FIXME: we could try_catch the above error, and then check if the
+            #        pool has anything worth to wait on.  That might be useful
+            #        for creation errors which are transient.  Alas, we don't
+            #        have any means to distinguish them from non-transient
+            #        errors, so we don't do that at this point...
+
             # check if we got an object
             if  obj is not None :
 

--- a/src/radical/utils/lease_manager.py
+++ b/src/radical/utils/lease_manager.py
@@ -175,8 +175,10 @@ class LeaseManager (object) :
                 pool['objects'].append (obj)
 
             except Exception as e :
-                obj = None
+                # this exception needs to fall through -- we can't wait
+                # for object creation problems to fix themself over time...
                 self._log.exception ("Could not create lease object")
+                raise
 
             return obj
 


### PR DESCRIPTION
This fixes https://github.com/radical-cybertools/saga-python/issues/451.  The underlying problem was an attempt to auto-optimize pool behavior wrt. ssh level connection sharing.  The pool manager was treating object creation failures _always_ as transient errors, and, instead of forwarding the error, then decided to wait on other leases to get freed.

This is now fixed: all creation errors are falling through now.  This implies that a pool size limit larger than the number of shared sessions supported by the system will now cause exceptions (instead of slow-downs).