### PR TITLE
Fix/double release

### DIFF
--- a/src/radical/utils/lease_manager.py
+++ b/src/radical/utils/lease_manager.py
@@ -390,11 +390,6 @@ class LeaseManager (object) :
 
             for pool_id in self._pools :
 
-                if instance in self._pools [pool_id]['freed']:
-                    # for now we ignore double-frees
-                    # FIXME: log warning
-                    return
-
                 for obj in self._pools [pool_id]['objects'] :
                     if  instance is not obj :
                         # this is not the object you are looking for.
@@ -423,7 +418,9 @@ class LeaseManager (object) :
                     # object has been released
                     return 
 
-            raise RuntimeError ("cannot release object -- not managed")
+            # FIXME: log warning
+            # for now we ignore double-frees
+            # raise RuntimeError ("cannot release object -- not managed")
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/utils/lease_manager.py
+++ b/src/radical/utils/lease_manager.py
@@ -390,10 +390,13 @@ class LeaseManager (object) :
 
             for pool_id in self._pools :
 
+                if instance in self._pools [pool_id]['freed']:
+                    # for now we ignore double-frees
+                    # FIXME: log warning
+                    return
+
                 for obj in self._pools [pool_id]['objects'] :
-
                     if  instance is not obj :
-
                         # this is not the object you are looking for.
                         continue
 
@@ -403,16 +406,13 @@ class LeaseManager (object) :
                     obj.release ()
 
                     if  delete :
-
                         # remove the object from the pool (decreasing its 
                         # ref counter and thus making it eligible for 
                         # garbage collection).  
-
                         self._pools [pool_id]['objects'].remove (obj)
                         self._pools [pool_id]['freed'] = None
 
                     else :
-
                         # mark the object as freed for lease.  
                         self._pools [pool_id]['freed'] = obj
 


### PR DESCRIPTION
duplicated freeing of shared resources indicates either a race condition in the lease manager, or a logic error in the user of the LM.  Either way, it actually happens at the point where the danger has *passed*, ie. after concurrent use of the leased channel, and we thus ignore this condition for now. 