### PR TITLE
Feature/raise on

### DIFF
--- a/src/radical/utils/debug.py
+++ b/src/radical/utils/debug.py
@@ -258,43 +258,51 @@ def get_caller_name(skip=2):
 
 # ------------------------------------------------------------------------------
 #
-_raise_on_cnt = dict()
-def raise_on(tag, n, log=None):
+_raise_on_state = dict()
+_raise_on_lock  = threading.Lock()
+def raise_on(tag, log=None):
     """
-    This is interpreted as follows: on the n'th invocation of this method with
-    any given tag, an exception is raised.  If n is '0', no exception is ever
-    raised.
+    The purpose of this method is to artificially trigger error conditions for
+    testing purposes, for example when handling the n'th unit, getting the n'th
+    heartbeat signal, etc.  
 
-    The purpose is to artificially trigger error conditions for testing 
-    purposes, for example when handling the n'th unit, getting the n'th 
-    heartbeat signal, etc.
+    The tag parameter is interpreted as follows: on the `n`'th invocation of
+    this method with any given `tag`, an exception is raised, and the counter
+    for that tag is rest.
+    
+    The limit `n` is set via an environment variable `RU_RAISE_ON_<tag>`, with
+    `tag` in upper casing.  The environment will only be inspected during the
+    first invocation of the method with any given tag.  The tag counter is
+    process local, but is shared amongst threads of that process.
     """
 
-    global _raise_on_cnt
+    global _raise_on_state
+    global _raise_on_lock
 
-    if log:
-        log.debug('raise_on check %s' % tag)
-    else:
-        print 'raise_on check %s' % tag
+    with _raise_on_lock:
 
-    if tag not in _raise_on_cnt:
-        _raise_on_cnt[tag] = 0 
-        
-    _raise_on_cnt[tag] += 1
+        if tag not in _raise_on_state:
+            _raise_on_state[tag] = { 
+                    'count' : 0,
+                    'limit' : os.environ('RU_RAISE_ON_%s' % tag.upper(), 0) 
+                    }
+            
+        _raise_on_state[tag]['count'] += 1
 
-    count = _raise_on_cnt[tag]
-    if log:
-        log.debug('raise_on check %s [%s / %s]' % (tag, count, n))
-    else:
-        print 'raise_on check %s [%s / %s]' % (tag, count, n)
+        count = _raise_on_state[tag]['count']
+        limit = _raise_on_state[tag]['limit']
 
-    if n and count >= n:
-        _raise_on_cnt[tag] = 0
-        if log:
-            log.error('raise_on for %s [%s]' % (tag, n))
-        else:
-            print 'raise_on for %s [%s]' % (tag, n)
-        raise RuntimeError('raise_on for %s [%s]' % (tag, n))
+        if log: log.debug('raise_on checked   %s [%s / %s]' % (tag, count, limit))
+        else:   print     'raise_on checked   %s [%s / %s]' % (tag, count, limit)
+
+        if limit and count == limit:
+
+            if log: log.error('raise_on triggered %s [%s]' % (tag, limit))
+            else:   print     'raise_on triggered %s [%s]' % (tag, limit)
+
+            # reset counter and raise exception
+            _raise_on_state[tag]['count'] = 0
+            raise RuntimeError('raise_on for %s [%s]' % (tag, limit))
 
 
 

--- a/src/radical/utils/debug.py
+++ b/src/radical/utils/debug.py
@@ -284,7 +284,7 @@ def raise_on(tag, log=None):
         if tag not in _raise_on_state:
             _raise_on_state[tag] = { 
                     'count' : 0,
-                    'limit' : os.environ('RU_RAISE_ON_%s' % tag.upper(), 0) 
+                    'limit' : os.environ.get('RU_RAISE_ON_%s' % tag.upper(), 0) 
                     }
             
         _raise_on_state[tag]['count'] += 1

--- a/src/radical/utils/debug.py
+++ b/src/radical/utils/debug.py
@@ -290,12 +290,12 @@ def raise_on(tag, log=None):
 
     The tag parameter is interpreted as follows: on the `n`'th invocation of
     this method with any given `tag`, an exception is raised, and the counter
-    for that tag is rest.
+    for that tag is reset.
     
     The limit `n` is set via an environment variable `RU_RAISE_ON_<tag>`, with
     `tag` in upper casing.  The environment will only be inspected during the
     first invocation of the method with any given tag.  The tag counter is
-    process local, but is shared amongst threads of that process.
+    process-local, but is shared amongst threads of that process.
     """
 
     global _raise_on_state

--- a/src/radical/utils/debug.py
+++ b/src/radical/utils/debug.py
@@ -257,4 +257,46 @@ def get_caller_name(skip=2):
 
 
 # ------------------------------------------------------------------------------
+#
+_raise_on_cnt = dict()
+def raise_on(tag, n, log=None):
+    """
+    This is interpreted as follows: on the n'th invocation of this method with
+    any given tag, an exception is raised.  If n is '0', no exception is ever
+    raised.
+
+    The purpose is to artificially trigger error conditions for testing 
+    purposes, for example when handling the n'th unit, getting the n'th 
+    heartbeat signal, etc.
+    """
+
+    global _raise_on_cnt
+
+    if log:
+        log.debug('raise_on check %s' % tag)
+    else:
+        print 'raise_on check %s' % tag
+
+    if tag not in _raise_on_cnt:
+        _raise_on_cnt[tag] = 0 
+        
+    _raise_on_cnt[tag] += 1
+
+    count = _raise_on_cnt[tag]
+    if log:
+        log.debug('raise_on check %s [%s / %s]' % (tag, count, n))
+    else:
+        print 'raise_on check %s [%s / %s]' % (tag, count, n)
+
+    if n and count >= n:
+        _raise_on_cnt[tag] = 0
+        if log:
+            log.error('raise_on for %s [%s]' % (tag, n))
+        else:
+            print 'raise_on for %s [%s]' % (tag, n)
+        raise RuntimeError('raise_on for %s [%s]' % (tag, n))
+
+
+
+# ------------------------------------------------------------------------------
 

--- a/src/radical/utils/threads.py
+++ b/src/radical/utils/threads.py
@@ -275,6 +275,8 @@ def cancel_main_thread(signame=None, once=False):
             os.kill(os.getpid(), signal)
         else:
             # this sends a SIGINT, resulting in a KeyboardInterrupt.
+            # NOTE: see http://bugs.python.org/issue23395 for problems on using
+            #       SIGINT in combination with signal handlers!
             thread.interrupt_main()
 
         # record the signal sending

--- a/src/radical/utils/threads.py
+++ b/src/radical/utils/threads.py
@@ -4,7 +4,10 @@ __copyright__ = "Copyright 2013, RADICAL@Rutgers"
 __license__   = "MIT"
 
 
+import os
 import sys
+import signal
+import thread
 import threading
 import traceback
 
@@ -221,14 +224,115 @@ def is_main_thread():
 
 # ------------------------------------------------------------------------------
 #
-def cancel_main_thread():
+_signal_lock = threading.Lock()
+_signal_sent = dict()
+def cancel_main_thread(signame=None, once=False):
+    """
+    This method will call thread.interrupt_main from any calling subthread.
+    That will cause a 'KeyboardInterrupt' exception in the main thread.  This
+    can be excepted via `except KeyboardInterrupt`
+    
+    The main thread MUST NOT have a SIGINT signal handler installed (other than
+    the default handler or SIGIGN), otherwise this call will cause an exception
+    in the core python signal handling (see http://bugs.python.org/issue23395).
 
+    The thread will exit after this, via sys.exit(0), and can then be joined
+    from the main thread.
+
+    When being called *from* the main thread, no interrupt will be generated,
+    but sys.exit() will still be called.  This can be excepted in the code via 
+    `except SystemExit:`.
+
+    Another way to avoid the SIGINT problem is to send a different signal to the
+    main thread.  We do so if `signal` is specified.
+
+    After sending the signal, any sub-thread will call sys.exit(), and thus
+    finish.  We leave it to the main thread thogh to decide if it will exit at
+    this point or not.  Either way, it will have to handle the signal first.
+
+    If `once` is set to `True`, we will send the given signal at most once.
+    This will mitigate races between multiple error causes, specifically during
+    finalization.
+    """
+
+    global _signal_lock
+    global _signal_sent
+
+
+    if signame: signal = get_signal_by_name(signame)
+    else      : signal = None
+
+
+    with _signal_lock:
+
+        if once:
+            if signal in _signal_sent:
+                # don't signal again
+                return
+
+        if signal:
+            # send the given signal to the process to which this thread belongs
+            os.kill(os.getpid(), signal)
+        else:
+            # this sends a SIGINT, resulting in a KeyboardInterrupt.
+            thread.interrupt_main()
+
+        # record the signal sending
+        _signal_sent[signal] = True
+
+
+    # the sub thread will at this point also exit.
     if not is_main_thread():
-        import thread
-        thread.interrupt_main()
+        sys.exit()
 
-    # this applies to the sub thread and the main thread
-    sys.exit()
+
+# ------------------------------------------------------------------------------
+#
+def get_signal_by_name(signame):
+    """
+    Translate a signal name into the respective signal number.  If `signame` is
+    not found to be a valid signal name, this method will raise a `KeyError`
+    exception.  Lookup is case insensitive.
+    """
+
+    table = {'abrt'    : signal.SIGABRT,
+             'alrm'    : signal.SIGALRM,
+             'bus'     : signal.SIGBUS,
+             'chld'    : signal.SIGCHLD,
+             'cld'     : signal.SIGCLD,
+             'cont'    : signal.SIGCONT,
+             'fpe'     : signal.SIGFPE,
+             'hup'     : signal.SIGHUP,
+             'ill'     : signal.SIGILL,
+             'int'     : signal.SIGINT,
+             'io'      : signal.SIGIO,
+             'iot'     : signal.SIGIOT,
+             'kill'    : signal.SIGKILL,
+             'pipe'    : signal.SIGPIPE,
+             'poll'    : signal.SIGPOLL,
+             'prof'    : signal.SIGPROF,
+             'pwr'     : signal.SIGPWR,
+             'quit'    : signal.SIGQUIT,
+             'rtmax'   : signal.SIGRTMAX,
+             'rtmin'   : signal.SIGRTMIN,
+             'segv'    : signal.SIGSEGV,
+             'stop'    : signal.SIGSTOP,
+             'sys'     : signal.SIGSYS,
+             'term'    : signal.SIGTERM,
+             'trap'    : signal.SIGTRAP,
+             'tstp'    : signal.SIGTSTP,
+             'ttin'    : signal.SIGTTIN,
+             'ttou'    : signal.SIGTTOU,
+             'urg'     : signal.SIGURG,
+             'usr1'    : signal.SIGUSR1,
+             'usr2'    : signal.SIGUSR2,
+             'vtalrm'  : signal.SIGVTALRM,
+             'winch'   : signal.SIGWINCH,
+             'xcpu'    : signal.SIGXCPU,
+             'xfsz'    : signal.SIGXFSZ,
+             }
+    
+    return table[signame.lower()]
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
```
    The purpose of this method is to artificially trigger error conditions for
    testing purposes, for example when handling the n'th unit, getting the n'th
    heartbeat signal, etc.  

    The tag parameter is interpreted as follows: on the `n`'th invocation of
    this method with any given `tag`, an exception is raised, and the counter
    for that tag is reset.
    
    The limit `n` is set via an environment variable `RU_RAISE_ON_<tag>`, with
    `tag` in upper casing.  The environment will only be inspected during the
    first invocation of the method with any given tag.  The tag counter is
    process-local, but is shared amongst threads of that process.
```