### PR TITLE
convert atfork monkeypatch exception into warning

### DIFF
--- a/src/radical/utils/atfork/stdlib_fixer.py
+++ b/src/radical/utils/atfork/stdlib_fixer.py
@@ -62,7 +62,8 @@ def fix_logging_module():
         # these exist, other loggers or not yet added handlers could as well.
         # Its safer to insist that this fix is applied before logging has been
         # configured.
-        raise Error('logging handlers already registered.')
+        warnings.warn('logging handlers already registered.')
+      # raise Error('logging handlers already registered.')
 
     logging._acquireLock()
     try:


### PR DESCRIPTION
See https://github.com/radical-cybertools/saga-python/issues/580.  Things will  usually work when this warning pops up, but the application will hang up if logging happens to be active in a thread while `fork()` is called in a different thread.