### PR TITLE
Fix/version strings

### DIFF
--- a/bin/radical-utils-version
+++ b/bin/radical-utils-version
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
+import sys
 import radical.utils as ru
 
-print ru.version_detail
+
+if len(sys.argv) > 1 and sys.argv[1] == '-v':
+    print ru.version_detail
+else:
+    print ru.version
 

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,7 @@ def get_version (mod_root):
 
         # make sure the version files exist for the runtime version inspection
         path = '%s/%s' % (src_root, mod_root)
-        print('creating %s/VERSION' % path)
         with open (path + "/VERSION", "w") as f:
-            print 'WRITING 1 %s' % version
             f.write (version + "\n")
 
         sdist_name = "%s-%s.tar.gz" % (name, version)
@@ -100,11 +98,6 @@ def get_version (mod_root):
         sdist_name = sdist_name.replace ('@', '-')
         sdist_name = sdist_name.replace ('#', '-')
         sdist_name = sdist_name.replace ('_', '-')
-
-        print('version: %s' % version)
-        print('base   : %s' % version_base)
-        print('detail : %s' % version_detail)
-        print('sdist  : %s' % sdist_name)
 
         if '--record'    in sys.argv or \
            'bdist_egg'   in sys.argv or \
@@ -121,14 +114,8 @@ def get_version (mod_root):
                          '%s/%s'   % (mod_root, sdist_name)) # copy into tree
             shutil.move ("VERSION.bak", "VERSION")           # restore version
 
-        print('creating %s/SDIST' % path)
         with open (path + "/SDIST", "w") as f: 
             f.write (sdist_name + "\n")
-
-        print('version: %s' % version)
-        print('base   : %s' % version_base)
-        print('detail : %s' % version_detail)
-        print('sdist  : %s' % sdist_name)
 
         return version_base, version_detail, sdist_name
 

--- a/setup.py
+++ b/setup.py
@@ -46,17 +46,16 @@ def get_version (mod_root):
 
     try:
 
-        version        = None
+        version_base   = None
         version_detail = None
 
         # get version from './VERSION'
         src_root = os.path.dirname (__file__)
-        if  not src_root :
+        if  not src_root:
             src_root = '.'
 
-        with open (src_root + '/VERSION', 'r') as f :
-            version = f.readline ().strip()
-
+        with open (src_root + '/VERSION', 'r') as f:
+            version_base = f.readline ().strip()
 
         # attempt to get version detail information from git
         # We only do that though if we are in a repo root dir, 
@@ -65,12 +64,12 @@ def get_version (mod_root):
         # and the pip version used uses an install tmp dir in the ve space
         # instead of /tmp (which seems to happen with some pip/setuptools 
         # versions).
-        p   = sp.Popen ('cd %s ; '\
-                        'test -z `git rev-parse --show-prefix` || exit -1; '\
-                        'tag=`git describe --tags --always` 2>/dev/null ; '\
-                        'branch=`git branch | grep -e "^*" | cut -f 2- -d " "` 2>/dev/null ; '\
-                        'echo $tag@$branch'  % src_root,
-                        stdout=sp.PIPE, stderr=sp.STDOUT, shell=True)
+        p = sp.Popen ('cd %s ; '\
+                      'test -z `git rev-parse --show-prefix` || exit -1; '\
+                      'tag=`git describe --tags --always` 2>/dev/null ; '\
+                      'branch=`git branch | grep -e "^*" | cut -f 2- -d " "` 2>/dev/null ; '\
+                      'echo $tag@$branch'  % src_root,
+                      stdout=sp.PIPE, stderr=sp.STDOUT, shell=True)
         version_detail = str(p.communicate()[0].strip())
         version_detail = version_detail.replace('detached from ', 'detached-')
 
@@ -78,30 +77,41 @@ def get_version (mod_root):
         version_detail = re.sub('[/ ]+', '-', version_detail)
         version_detail = re.sub('[^a-zA-Z0-9_+@.-]+', '', version_detail)
 
-
         if  p.returncode   !=  0  or \
             version_detail == '@' or \
             'not-a-git-repo' in version_detail or \
             'not-found'      in version_detail or \
             'fatal'          in version_detail :
-            version_detail =  version
-
-        print('version: %s (%s)' % (version, version_detail))
-
+            version = version_base
+        elif '@' not in version_base:
+            version = '%s-%s' % (version_base, version_detail)
+        else:
+            version = version_base
 
         # make sure the version files exist for the runtime version inspection
         path = '%s/%s' % (src_root, mod_root)
         print('creating %s/VERSION' % path)
-        with open (path + "/VERSION", "w") as f : f.write (version_detail + "\n")
+        with open (path + "/VERSION", "w") as f:
+            print 'WRITING 1 %s' % version
+            f.write (version + "\n")
 
-        sdist_name = "%s-%s.tar.gz" % (name, version_detail)
+        sdist_name = "%s-%s.tar.gz" % (name, version)
         sdist_name = sdist_name.replace ('/', '-')
         sdist_name = sdist_name.replace ('@', '-')
         sdist_name = sdist_name.replace ('#', '-')
         sdist_name = sdist_name.replace ('_', '-')
-        if '--record'  in sys.argv or 'bdist_egg' in sys.argv or 'bdist_wheel' in sys.argv:
-           # pip install stage 2      easy_install stage 1
-           # NOTE: pip install will untar the sdist in a tmp tree.  In that tmp
+
+        print('version: %s' % version)
+        print('base   : %s' % version_base)
+        print('detail : %s' % version_detail)
+        print('sdist  : %s' % sdist_name)
+
+        if '--record'    in sys.argv or \
+           'bdist_egg'   in sys.argv or \
+           'bdist_wheel' in sys.argv    :
+           # pip install stage 2 or easy_install stage 1
+           #
+           # pip install will untar the sdist in a tmp tree.  In that tmp
            # tree, we won't be able to derive git version tags -- so we pack the
            # formerly derived version as ./VERSION
             shutil.move ("VERSION", "VERSION.bak")           # backup version
@@ -112,9 +122,15 @@ def get_version (mod_root):
             shutil.move ("VERSION.bak", "VERSION")           # restore version
 
         print('creating %s/SDIST' % path)
-        with open (path + "/SDIST", "w") as f : f.write (sdist_name + "\n")
+        with open (path + "/SDIST", "w") as f: 
+            f.write (sdist_name + "\n")
 
-        return version, version_detail, sdist_name
+        print('version: %s' % version)
+        print('base   : %s' % version_base)
+        print('detail : %s' % version_detail)
+        print('sdist  : %s' % sdist_name)
+
+        return version_base, version_detail, sdist_name
 
     except Exception as e :
         raise RuntimeError ('Could not extract/set version: %s' % e)
@@ -129,6 +145,10 @@ if  sys.hexversion < 0x02070000 or sys.hexversion >= 0x03000000:
 # ------------------------------------------------------------------------------
 # get version info -- this will create VERSION and srcroot/VERSION
 version, version_detail, sdist_name = get_version (mod_root)
+
+print('version: %s' % version)
+print('detail : %s' % version_detail)
+print('sdist  : %s' % sdist_name)
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/utils/__init__.py
+++ b/src/radical/utils/__init__.py
@@ -55,7 +55,9 @@ import os
 
 _mod_root = os.path.dirname (__file__)
 
-version, version_detail, version_branch, sdist_name, sdist_path = get_version()
+version_short, version_detail, version_base, \
+               version_branch, sdist_name, sdist_path = get_version()
+version = version_short
 
 # ------------------------------------------------------------------------------
 

--- a/src/radical/utils/get_version.py
+++ b/src/radical/utils/get_version.py
@@ -5,20 +5,21 @@ import os
 import sys
 import subprocess    as sp
 
+_pat = '^\s*(?P<detail>(?P<short>[^-]*)-(?P<base>[^-@]+?)(-[^@]+?)?(?P<branch>@.+?)?)\s*$'
 
 # ------------------------------------------------------------------------------
 #
 # versioning mechanism:
 #
-#   - short_version:  1.2.3                   - is used for installation
-#   - long_version:   1.2.3-9-g0684b06-devel  - is used as runtime (ru.version)
+#   - version_short :  1.2.3                       - used for installation
+#   - version_detail:  1.2.3-v1.1-9-g0684b06@devel - used at runtime (ru.version)
 #   - both are derived from the last git tag and branch information
-#   - VERSION files are created on install, with the long_version
+#   - VERSION files are created on install, with the version_detail
 #
 def get_version (paths=None):
     """
     paths:
-        a VERSION file containing the long version is checked for in every
+        a VERSION file containing the detailed version is checked for in every
         directory listed in paths.   When we find a VERSION file, we also look
         for an SDIST file, and return the found name and location as absolute
         path to the sdist.
@@ -33,33 +34,38 @@ def get_version (paths=None):
     if not isinstance (paths, list):
         paths = [paths]
     
-    long_version  = None
-    short_version = None
-    branch_name   = None
-    sdist_name    = None
-    sdist_path    = None
-    version_path  = None
+    version_short  = None
+    version_detail = None
+    version_base   = None
+    version_branch = None
+    sdist_name     = None
+    sdist_path     = None
     
     
-    # if in any of the paths a VERSION file exists, we use the long version
+    # if in any of the paths a VERSION file exists, we use the detailed version
     # in there.
     for path in paths:
     
         try:
-    
             version_path = "%s/VERSION" % path
     
             with open (version_path) as f:
                 line = f.readline()
                 line.strip()
-                pattern = re.compile ('^\s*(?P<long>(?P<short>[^-@]+?)(-[^@]+?)?(?P<branch>@.+?)?)\s*$')
+                pattern = re.compile (_pat)
                 match   = pattern.search (line)
     
                 if match:
-                    long_version  = match.group ('long')
-                    short_version = match.group ('short')
-                    branch_name   = match.group ('branch')
-                  # print 'reading  %s' % version_path
+                    version_short  = match.group ('short')
+                    version_detail = match.group ('detail')
+                    version_base   = match.group ('base')
+                    version_branch = match.group ('branch')
+                  # print 'reading        : %s' % version_path
+                  # print '               : %s' % line
+                  # print 'version_base   : %s' % version_base
+                  # print 'version_detail : %s' % version_detail
+                  # print 'version_short  : %s' % version_short
+                  # print 'version_branch : %s' % version_branch
                     break
     
         except Exception as e:
@@ -67,7 +73,7 @@ def get_version (paths=None):
             pass
 
 
-    if long_version:
+    if version_detail:
         # check if there is also an SDIST near the version_path
         sdist_path = version_path.replace ('/VERSION', '/SDIST')
         try:
@@ -79,8 +85,9 @@ def get_version (paths=None):
         sdist_path = version_path.replace ('/VERSION', '/%s' % sdist_name)
 
     # check if any one worked ok
-    if long_version:
-        return short_version, long_version, branch_name, sdist_name, sdist_path
+    if version_detail:
+        return (version_short, version_detail, version_base, \
+                version_branch, sdist_name, sdist_path)
     else:
         raise RuntimeError ("Cannot determine version from %s" % paths)
     


### PR DESCRIPTION
naming of version elements is now consistent, current VERSION content is correctly reflected.
This fixes a problem which came up when looking to correct the VE names for pilot agents.