### PR TITLE
added a handle-None check in the flush method of profile

### DIFF
--- a/src/radical/utils/profile.py
+++ b/src/radical/utils/profile.py
@@ -172,8 +172,8 @@ class Profiler(object):
     #
     def flush(self, verbose=True):
 
-        if not self._enabled:
-            return
+        if not self._enabled: return
+        if not self._handle : return
 
         if self._enabled:
 


### PR DESCRIPTION
simple `if not self._handle` check in the `flush()` method of the profiler, similar to what is done in the `prof()` method.