### PR TITLE
relocate ID state storage in absence of `$HOME`

### DIFF
--- a/src/radical/utils/ids.py
+++ b/src/radical/utils/ids.py
@@ -13,7 +13,7 @@ import datetime
 import threading
 import singleton
 
-from .misc import dockerized
+from .misc import dockerized, get_radical_base
 
 
 # ------------------------------------------------------------------------------
@@ -78,13 +78,10 @@ class _IDRegistry(object):
 # ------------------------------------------------------------------------------
 #
 # we create on private singleton instance for the ID registry.
+#
 _id_registry = _IDRegistry()
-_BASE        = "%s/.radical/utils" % os.environ.get("HOME", "/tmp")
+_BASE        = get_radical_base('utils')
 
-try:
-    os.makedirs(_BASE)
-except:
-    pass
 
 # ------------------------------------------------------------------------------
 #
@@ -155,7 +152,8 @@ def generate_id(prefix, mode=ID_SIMPLE, namespace=None):
         re.session.vivek-HP-Pavilion-m6-Notebook-PC.vivek.017548.0001 pipeline.0000
         re.session.vivek-HP-Pavilion-m6-Notebook-PC.vivek.017548.0001 pipeline.0001
 
-    The namespaces are stored under ```$HOME/.radical/utils/```
+    The namespaces are stored under ```$RADICAL_BASE_DIR/.radical/utils/```.  If
+    `RADICAL_BASE_DIR` is not set, then `$HOME` is used.
 
     Note that for docker containers, we try to avoid hostname / username clashes
     and will, for `ID_PRIVATE`, revert to `ID_UUID`.

--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -552,4 +552,38 @@ def sh_callout(cmd, shell=False):
 
 
 # ------------------------------------------------------------------------------
+#
+def get_radical_base(module=None):
+    '''
+    Several parts of the RCT stack store state on the file system.  This should
+    usually be under `$HOME/.radical` - but that location is not always
+    available or desireable.  We interpret the env variable `RADICAL_BASE_DIR`,
+    and fall back to `pwd` if neither that nor `$HOME` exists.
 
+    The optional `module` parameter will result in the respective subdir name to
+    be appended.  The resulting dir is created (if it does not exist), and the
+    name is returned.
+    '''
+
+
+    base = os.environ.get("RADICAL_BASE_DIR")
+
+    if not base or not os.path.isdir(base):
+        base  = os.environ.get("HOME")
+
+    if not base or not os.path.isdir(base):
+        base  = os.environ.get("PWD")
+
+    if not base or not os.path.isdir(base):
+        base  = os.getcwd()
+
+    if module: base += '/.radical/%s/' % module
+    else     : base += '/.radical/'
+
+    if not os.path.isdir(base):
+        os.makedirs(base)
+
+    return base
+
+
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
This recently popped up on titan (see radical-cybertools/radical.pilot/issues/1538)