### PR TITLE
handle None messages in watcher

### DIFF
--- a/src/radical/utils/process.py
+++ b/src/radical/utils/process.py
@@ -332,12 +332,8 @@ class Process(mp.Process):
                 msg = self._ru_msg_recv(_BUFSIZE)
                 self._ru_log.info('message received: %s' % msg)
 
-                if msg is None:
-                    self._ru_log.warn('received no message, parent closed ep?')
-                    return False
-
-                if msg == '':
-                    self._ru_log.warn('received empty string, parent closed ep!')
+                if msg in [None, '']:
+                    self._ru_log.warn('no message, parent closed ep!')
                     return False
 
                 if msg.strip() == 'STOP':

--- a/src/radical/utils/process.py
+++ b/src/radical/utils/process.py
@@ -331,8 +331,13 @@ class Process(mp.Process):
 
                 msg = self._ru_msg_recv(_BUFSIZE)
                 self._ru_log.info('message received: %s' % msg)
+
+                if msg is None:
+                    self._ru_log.warn('received no message, parent closed ep?')
+                    return False
+
                 if msg == '':
-                    self._ru_log.warn('received empty string, parent closed ep')
+                    self._ru_log.warn('received empty string, parent closed ep!')
                     return False
 
                 if msg.strip() == 'STOP':


### PR DESCRIPTION
This ensures that a `None` type  message on a closing or interrupted endpoint is correctly handled.