### PR TITLE
support callbacks for heartbeat management

### DIFF
--- a/src/radical/utils/config.py
+++ b/src/radical/utils/config.py
@@ -156,6 +156,14 @@ class Config(DictMixin):
     def __init__(self, module, path=None, name=None, cfg=None,
                        expand=True, env=None):
         '''
+        Load a config (json) file from the module's config tree, and overload
+        any user specific config settings if found.
+
+        module:  used to determine the module's config file location
+        path:    full path to a config file (leading module name elements are
+                 strippeed)
+        name:    the path is here determined by module name and config name
+        cfg:     runtime config settings to be merged into the default config
         expand:  enable / disable environment var expansion.  When disabled, the
                  consumer should expand manually upon use of config entries.
         env:     environment dictionary to be used for expansion
@@ -251,12 +259,11 @@ class Config(DictMixin):
                     ucfg = read_json(usr_fname)
                     usr_cfg[base] = ucfg
 
-
         # merge sys, app, and user cfg before expansion
         self._cfg = dict()
         self._cfg = dict_merge(self._cfg, sys_cfg, policy='overwrite')
-        self._cfg = dict_merge(self._cfg, app_cfg, policy='overwrite')
         self._cfg = dict_merge(self._cfg, usr_cfg, policy='overwrite')
+        self._cfg = dict_merge(self._cfg, app_cfg, policy='overwrite')
 
         if expand:
             ru_expand_env(self._cfg, env=env)

--- a/src/radical/utils/heartbeat.py
+++ b/src/radical/utils/heartbeat.py
@@ -12,18 +12,31 @@ class Heartbeat(object):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, uid, timeout, interval=1, log=None):
+    def __init__(self, uid, timeout, interval=1, cb=None, term=None, log=None):
         '''
         This is a simple hearteat monitor: after construction, it's `beat()`
         method needs to be called in intervals shorter than the given `timeout`
         value.  A thread will be created which checks if heartbeats arrive
         timely - if not, the current process is killed via `os.kill()`.
+
+        If a callback `cb` is specified, the watcher will also invoke that
+        callback after every `interval` seconds.  This can be used to ensure
+        heartbeats by the owning instance (which may feed this or any other
+        `Heartbeat` monitor instance).  The `term` callback is invoked on
+        heartbeat failure, i.e., just before the process is killed.
         '''
+
+        if interval > timeout:
+            raise ValueError('timeout [%.1f] too small [>%.1f]'
+                            % (timeout, interval))
 
         self._uid      = uid
         self._log      = log
         self._timeout  = timeout
         self._interval = interval
+        self._cb       = cb
+        self._term     = term
+
         self._tstamps  = dict()
         self._pid      = os.getpid()
 
@@ -41,6 +54,9 @@ class Heartbeat(object):
             time.sleep(self._interval)
             now = time.time()
 
+            if  self._cb:
+                self._cb()
+
             # avoid iteration over changing dict
             uids = list(self._tstamps.keys())
             for uid in uids:
@@ -55,6 +71,9 @@ class Heartbeat(object):
                     if self._log:
                         self._log.warn('hb %s[%s]: %.1f - %.1f > %1.f: timeout',
                                        self._uid, uid, now, last, self._timout)
+
+                    if  self._term:
+                        self._term()
 
                     os.kill(self._pid, signal.SIGTERM)
 


### PR DESCRIPTION
This PR adds heartbeat callbacks, to simplify lifetime management in the RCT stack.  Specifically, an RP component or session can use those callbacks to regularly send heartbeats on the HB channel.