### PR TITLE
py3 miniconda installs gtod, but complains

### DIFF
--- a/bin/radical-utils-gtod
+++ b/bin/radical-utils-gtod
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if test -z "$EPOCHREALTIME"
+then
+    python3 -c 'import time; print("%.6f" % time.time())'
+else
+    echo ${EPOCHREALTIME:0:17}
+fi
+

--- a/setup.py
+++ b/setup.py
@@ -163,17 +163,18 @@ def read(*rnames):
 
 # ------------------------------------------------------------------------------
 # FIXME: pip3 bug: binaries files cannot be installed into bin.
-# compile gtod
-try:
-    compiler = new_compiler(verbose=1)
-    objs = compiler.compile(sources=['src/radical/utils/gtod.c'])
-    exe  = compiler.link_executable(objs, 'bin/radical-utils-gtod')
-except:
-    with open('bin/radical-utils-gtod', 'w') as fout:
-        fout.write('#!/usr/bin/env python\n'
-                   'import time\n'
-                   'print time.time()\n')
-    os.chmod('bin/radical-utils-gtod', 0o755)
+# NOTE : disable to avoid stupid/inconsequrntial bwheel error
+# # compile gtod
+# try:
+#     compiler = new_compiler(verbose=1)
+#     objs = compiler.compile(sources=['src/radical/utils/gtod.c'])
+#     exe  = compiler.link_executable(objs, 'bin/radical-utils-gtod')
+# except:
+#     with open('bin/radical-utils-gtod', 'w') as fout:
+#         fout.write('#!/usr/bin/env python\n'
+#                    'import time\n'
+#                    'print time.time()\n')
+#     os.chmod('bin/radical-utils-gtod', 0o755)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
revert to shell based gtod again, to avoid user confusion