### PR TITLE
speed up uid generation

### DIFF
--- a/src/radical/utils/ids.py
+++ b/src/radical/utils/ids.py
@@ -277,10 +277,10 @@ def _generate_id(template, prefix, ns=None):
     ret = template % info
 
     if '%(' in ret:
-      # import pprint
-      # pprint.pprint(info)
-      # print template
-      # print ret
+        # import pprint
+        # pprint.pprint(info)
+        # print(template)
+        # print(ret)
         raise ValueError('unknown pattern in template (%s)' % template)
 
     return ret

--- a/src/radical/utils/ids.py
+++ b/src/radical/utils/ids.py
@@ -21,6 +21,13 @@ TEMPLATE_PRIVATE = "%(prefix)s.%(host)s.%(user)s.%(days)06d.%(day_counter)04d"
 TEMPLATE_UUID    = "%(prefix)s.%(uuid)s"
 
 
+_cache = {'dir'        : list(),
+          'user'       : None,
+          'pid'        : os.getpid(),
+          'dockerized' : dockerized(),
+          }
+
+
 # ------------------------------------------------------------------------------
 #
 class _IDRegistry(object, metaclass=Singleton):
@@ -172,7 +179,7 @@ def generate_id(prefix, mode=ID_SIMPLE, ns=None):
 
     template = ""
 
-    if dockerized() and mode == ID_PRIVATE:
+    if _cache['dockerized'] and mode == ID_PRIVATE:
         mode = ID_UUID
 
     if   mode == ID_CUSTOM : template = prefix
@@ -193,26 +200,30 @@ def _generate_id(template, prefix, ns=None):
     # rarely used in IDs.  They should be created only once per module instance,
     # and/or only if needed.
 
-    import getpass
+    global _cache
 
     state_dir = _BASE
     if ns:
         state_dir += '/%s' % ns
 
-    try:
-        os.makedirs(state_dir)
-    except:
-        pass
+    if state_dir not in _cache['dir']:
+        try   : os.makedirs(state_dir)
+        except: pass
+        _cache['dir'].append(state_dir)
 
     # seconds since epoch(float), and timestamp
     seconds = time.time()
     now     = datetime.datetime.fromtimestamp(seconds)
     days    = int(seconds / (60 * 60 * 24))
 
-    try:
-        user = getpass.getuser()
-    except:
-        user = 'nobody'
+    if not _cache['user']:
+        try:
+            import getpass
+            _cache['user'] = getpass.getuser()
+        except:
+            _cache['user'] = 'nobody'
+
+    user = _cache['user']
 
     info = dict()
 
@@ -226,7 +237,7 @@ def _generate_id(template, prefix, ns=None):
     info['now'         ] = now
     info['date'        ] = "%04d.%02d.%02d" % (now.year, now.month,  now.day)
     info['time'        ] = "%02d.%02d.%02d" % (now.hour, now.minute, now.second)
-    info['pid'         ] = os.getpid()
+    info['pid'         ] = _cache['pid']
 
     # the following ones are time consuming, and only done when needed
     if '%(host)' in template: info['host'] = socket.gethostname()  # localhost
@@ -271,10 +282,6 @@ def _generate_id(template, prefix, ns=None):
       # print template
       # print ret
         raise ValueError('unknown pattern in template (%s)' % template)
-
-    if 'client_notify' in ret and 'get' in ret:
-        from .debug import print_stacktrace
-        print_stacktrace(ret)
 
     return ret
 


### PR DESCRIPTION
test: generating 1m simple IDs
before:
```shell
(ve3)  rivendell  merzky  ~/radical/radical.utils.devel  [optimize/generate_id *] $ time ./t.py
16.283207654953003
r:0m16.415s  u:0m14.472s  s:0m1.941s
```

after:
```shell
(ve3)  rivendell  merzky  ~/radical/radical.utils.devel  [optimize/generate_id] $ time ./t.py
3.7440223693847656
r:0m3.909s  u:0m3.877s  s:0m0.032s
```

runtime reduced to ~25%, but more importantly system load reduced to ~2% due to reduced number of hits on the file system.  This has a much larger impact on shared file systems.