### PR TITLE
Handling 'None' value in method misc.as_tuple()

### DIFF
--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -319,7 +319,7 @@ def as_tuple(data):
     return non-tuple data into a tuple.
     '''
 
-    if   data is None  : return
+    if   data is None  : return tuple()
     elif is_tuple(data): return data
     else               : return (data, )
 


### PR DESCRIPTION
If input data is None then method should return empty tuple. Later this method is used in [description](https://github.com/radical-cybertools/radical.utils/blob/02fa57a326b1b1ca296e88b039c3ada4a46886fa/src/radical/utils/description.py#L150) module and the value should be iterable