### PR TITLE
var consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - COVERAGE=false
     - PYTEST="coverage run -m pytest -ra --timeout=600 -vvv --showlocals"
     - RADICAL_DEBUG=True
+    - RADICAL_DEBUG_HELPER=True
 
   matrix:
     - MAIN_CMD="$PYTEST tests/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CODECOV_TOKEN="18d4cc7a-d35c-44ec-9684-e6f2ec7702fc"
     - COVERAGE=false
     - PYTEST="coverage run -m pytest -ra --timeout=600 -vvv --showlocals"
+    - RADICAL_DEBUG=True
 
   matrix:
     - MAIN_CMD="$PYTEST tests/"

--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -850,7 +850,11 @@ def get_radical_base(module=None):
         if module.startswith('radical/'):
             module = module[8:]
 
-    base = os.environ.get("RADICAL_BASE_DIR")
+    base = os.environ.get("RADICAL_BASE")
+
+    if not base:
+        # backward compatibility
+        base = os.environ.get("RADICAL_BASE_DIR")
 
     if not base or not os.path.isdir(base):
         base  = os.environ.get("HOME")


### PR DESCRIPTION
Two different versions of the env var crept into our code / use, and this fix allows for that.  In the long run, `RADICAL_BASE_DIR` should be retired.