### PR TITLE
Fix to respect default values of Munch-based attributes

### DIFF
--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -92,19 +92,23 @@ class Munch(DictMixin):
         if not other:
             return
 
-        for k,v in other.items():
+        for k, v in other.items():
             if isinstance(v, dict):
                 t = self._schema.get(k)
                 if not t:
                     t = type(self)
                 if not isinstance(t, dict):
-                    if (issubclass(type(v), Munch)):
-                        # no need to recast)
+                    if issubclass(type(v), Munch):
+                        # no need to recast
                         pass
                     elif issubclass(t, Munch):
                         # cast to expected Munch type
                         v = t(from_dict=v)
-            self[k] = v
+
+            if self._data.get(k) and issubclass(type(v), Munch):
+                self[k].merge(v, expand=False)
+            else:
+                self[k] = v
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -17,7 +17,7 @@ from .misc       import as_list, as_tuple
 from .misc       import is_string
 from .misc       import expand_env as ru_expand_env
 from .dict_mixin import DictMixin, dict_merge
-from .json_io    import read_json, write_json
+from .json_io    import write_json
 
 
 # ------------------------------------------------------------------------------

--- a/tests/unittests/test_misc.py
+++ b/tests/unittests/test_misc.py
@@ -200,8 +200,6 @@ def test_expand_env():
 #
 def test_script_2_func():
 
-    biz = '?'
-
     # create a temp script to convert and run
     [tmpfile, tmpname] = tempfile.mkstemp()
     os.write(tmpfile, ru.as_bytes("""#!/usr/bin/env python3

--- a/tests/unittests/test_munch.py
+++ b/tests/unittests/test_munch.py
@@ -9,7 +9,7 @@ import radical.utils as ru
 def test_munch():
     # note that test_description.py also tests large parts of the Munch class in
     # a non-hierarchical setup.  This test is focused on inheritance: note that
-    # all classes inherit from ru.Config which is also Munch drivate, but
+    # all classes inherit from ru.Config which is also Munch derivative, but
     # provides simpler initialization which we use in these tests.
 
     # --------------------------------------------------------------------------
@@ -124,10 +124,55 @@ def test_munch():
 
 # ------------------------------------------------------------------------------
 #
+def test_munch_update():
+
+    # --------------------------------------------------------------------------
+    # plain schema
+    class Bar_1(ru.Munch):
+        _schema = {'one': int,
+                   'two': {str: int}}
+
+    # --------------------------------------------------------------------------
+    # class whose schema is composed
+    class Buz_1(ru.Munch):
+        _schema = {'foo': int,
+                   'bar': Bar_1}
+
+    # --------------------------------------------------------------------------
+    # class whose schema is composed and has default values
+    class Foo_1(ru.Munch):
+        _schema   = {'buz': Buz_1}
+        _defaults = {'buz': {'foo': 0,
+                             'bar': {'one': 1,
+                                     'two': {'sub-two': 2}}}}
+
+        def __init__(self, from_dict=None):
+            super().__init__(from_dict=self._defaults)
+            if from_dict:
+                self.update(from_dict)
+
+    f = Foo_1()
+    assert(f.buz.foo == 0)
+    assert(f.buz.bar.two['sub-two'] == 2)
+
+    f = Foo_1({'buz': {'foo': 3,
+                       'bar': {'one': 11}}})
+    assert(f.buz.bar.one == 11)
+    assert(f.buz.bar.two['sub-two'] == 2)
+
+    f = Foo_1({'buz': {'foo': 3,
+                       'bar': {'one': 0,
+                               'two': {2: 22}}}})
+    f.verify()  # method `verify` convert int into str according to the scheme
+    assert(f.buz.bar.two['2'] == 22)
+
+
+# ------------------------------------------------------------------------------
+#
 if __name__ == '__main__':
 
     test_munch()
-
+    test_munch_update()
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Default values of attributes of Munch-based types are ignored with method `update`

Examples are based on `Config` class (pure Munch-based) from `radical.dreamer`
```
>>> from radical.dreamer import Config
```
1) create an instance with default values:
```
>>> cfg = Config()
>>> print(pprint.pformat(cfg))
{'rabbitmq': {'exchange': 'rd',
              'queues': {'allocation': 'allocation',
                         'request': 'request',
                         'resource': 'resource',
                         'schedule': 'schedule',
                         'session': 'session',
                         'workload': 'workload'},
              'url': 'amqp://localhost:5672/'},
 'session': {'early_binding': True,
             'output_profile': 'profile.json',
             'schedule_options': []}}
```
2) instance with default values except one:
```
>>> cfg = Config({'rabbitmq': {'url': 'nourl'}})
>>> print(pprint.pformat(cfg))
{'rabbitmq': {'url': 'nourl'},
 'session': {'early_binding': True,
             'output_profile': 'profile.json',
             'schedule_options': []}}
```
If attributes are of Munch-based type with some default values, then these default values should be considered in the `update` method (thus it is only related to Munch-based attributes)

**edit:** [link](https://github.com/radical-project/radical.dreamer/blob/master/src/radical/dreamer/configs/_base.py#L34) to `Config` class