### PR TITLE
handle defaults the same way as schema

### DIFF
--- a/src/radical/utils/description.py
+++ b/src/radical/utils/description.py
@@ -31,9 +31,6 @@ class Description(Munch):
     #
     def __init__(self, from_dict=None, verify_setter=False):
 
-        if not hasattr(self, '_schema'):
-            raise RuntimeError('class %s has no schema defined' % self.__name__)
-
         super(Description, self).__init__(from_dict=from_dict)
 
         if verify_setter:

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -64,10 +64,10 @@ class Munch(DictMixin):
         self._data = dict()
 
         if defaults:
-            self.update(defaults)
+            self.update(copy.deepcopy(defaults))
 
         elif hasattr(self, '_defaults'):
-            self.update(self._defaults)
+            self.update(copy.deepcopy(self._defaults))
 
         self.update(from_dict)
 
@@ -99,7 +99,6 @@ class Munch(DictMixin):
             return
 
         for k, v in other.items():
-            v = copy.deepcopy(v)
             if isinstance(v, dict):
                 t = self._schema.get(k)
                 if not t:
@@ -107,10 +106,7 @@ class Munch(DictMixin):
                 if isinstance(t, type) and \
                         issubclass(t, Munch) and not issubclass(type(v), Munch):
                     # cast to expected Munch type
-                    options = {'from_dict': v}
-                    if self._data.get(k):
-                        options['defaults'] = self[k]
-                    v = t(**options)
+                    v = t(from_dict=v, defaults=self._data.get(k))
             self[k] = v
 
 
@@ -136,7 +132,7 @@ class Munch(DictMixin):
         # Munch-based type then `verify` method will raise TypeError exception
         #
         # attrs `_defaults` and `_data` will be deepcopied in `update` method
-        return type(self)(from_dict=self._data)
+        return type(self)(from_dict=copy.deepcopy(self._data))
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -26,7 +26,7 @@ class Munch(DictMixin):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, from_dict=None, schema=None, defaults=None):
+    def __init__(self, from_dict=None):
         '''
         create a munchified dictionary (tree) from `from_dict`.
 
@@ -54,19 +54,13 @@ class Munch(DictMixin):
               Names with a leading underscore are not supported.
         '''
 
-        if schema:
-            self._schema = schema
-
-        elif not hasattr(self, '_schema'):
+        if not hasattr(self, '_schema'):
             self._schema = dict()
           # raise RuntimeError('class %s has no schema defined' % self.__name__)
 
         self._data = dict()
 
-        if defaults:
-            self.update(copy.deepcopy(defaults))
-
-        elif hasattr(self, '_defaults'):
+        if hasattr(self, '_defaults'):
             self.update(copy.deepcopy(self._defaults))
 
         self.update(from_dict)
@@ -106,7 +100,8 @@ class Munch(DictMixin):
                 if isinstance(t, type) and \
                         issubclass(t, Munch) and not issubclass(type(v), Munch):
                     # cast to expected Munch type
-                    v = t(from_dict=v, defaults=self._data.get(k))
+                    self._data.setdefault(k, t()).update(v)
+                    continue
             self[k] = v
 
 
@@ -130,8 +125,6 @@ class Munch(DictMixin):
         # should return a new instance of the same type, not an original Munch,
         # otherwise if an instance of Munch-based has an attribute of another
         # Munch-based type then `verify` method will raise TypeError exception
-        #
-        # attrs `_defaults` and `_data` will be deepcopied in `update` method
         return type(self)(from_dict=copy.deepcopy(self._data))
 
 

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -26,7 +26,7 @@ class Munch(DictMixin):
 
     # --------------------------------------------------------------------------
     #
-    def __init__(self, from_dict=None, schema=None):
+    def __init__(self, from_dict=None, schema=None, defaults=None):
         '''
         create a munchified dictionary (tree) from `from_dict`.
 
@@ -63,7 +63,13 @@ class Munch(DictMixin):
 
         self._data = dict()
 
-        self.update(copy.deepcopy(from_dict))
+        if defaults:
+            self.update(defaults)
+
+        elif hasattr(self, '_defaults'):
+            self.update(self._defaults)
+
+        self.update(from_dict)
 
 
     # --------------------------------------------------------------------------

--- a/tests/unittests/test_description.py
+++ b/tests/unittests/test_description.py
@@ -96,8 +96,7 @@ def test_inheritance():
         _defaults = {'i245': [   ]}
 
         def __init__(self, from_dict=None):
-
-            ru.Description.__init__(self, from_dict=self._defaults)
+            ru.Description.__init__(self)
 
 
     # --------------------------------------------------------------------------

--- a/tests/unittests/test_description.py
+++ b/tests/unittests/test_description.py
@@ -96,8 +96,7 @@ def test_inheritance():
         _defaults = {'i245': [   ]}
 
         def __init__(self, from_dict=None):
-            ru.Description.__init__(self)
-
+            ru.Description.__init__(self, from_dict=from_dict)
 
     # --------------------------------------------------------------------------
     td = _Test()

--- a/tests/unittests/test_munch.py
+++ b/tests/unittests/test_munch.py
@@ -149,9 +149,6 @@ def test_munch_update():
                              'bar': {'one': 1,
                                      'two': {'sub-two': 2}}}}
 
-        def __init__(self, from_dict=None, defaults=None):
-            super().__init__(from_dict=from_dict, defaults=defaults)
-
     # --------------------------------------------------------------------------
     f = Foo_1()
     assert (f.buz.foo == 0)
@@ -166,13 +163,10 @@ def test_munch_update():
     f = Foo_1({'buz': {'foo': 3,
                        'bar': {'one': 0,
                                'two': {2: 22}}}})
-    f.verify()  # method `verify` convert int into str according to the scheme
+    f.verify()  # method `verify` convert int into str according to the schema
     assert (f.buz.bar.two['2'] == 22)
 
     f = Foo_1()
-    # default values from Foo_1 class
-    assert (f.buz.bar['two'] == {'sub-two': 2})
-    assert (f.buz.bar['one'] == 1)
     b = Bar_1()
     f.update({'buz': {'bar': b}})
     # default values from Bar_1 class

--- a/tests/unittests/test_munch.py
+++ b/tests/unittests/test_munch.py
@@ -129,8 +129,11 @@ def test_munch_update():
     # --------------------------------------------------------------------------
     # plain schema
     class Bar_1(ru.Munch):
-        _schema = {'one': int,
-                   'two': {str: int}}
+        _schema   = {'one'  : int,
+                     'two'  : {str: int},
+                     'three': [str]}
+        _defaults = {'two'  : {'two-default': 0},
+                     'three': [3, 3, 3]}
 
     # --------------------------------------------------------------------------
     # class whose schema is composed
@@ -146,25 +149,36 @@ def test_munch_update():
                              'bar': {'one': 1,
                                      'two': {'sub-two': 2}}}}
 
-        def __init__(self, from_dict=None):
-            super().__init__(from_dict=self._defaults)
-            if from_dict:
-                self.update(from_dict)
+        def __init__(self, from_dict=None, defaults=None):
+            super().__init__(from_dict=from_dict, defaults=defaults)
 
+    # --------------------------------------------------------------------------
     f = Foo_1()
-    assert(f.buz.foo == 0)
-    assert(f.buz.bar.two['sub-two'] == 2)
+    assert (f.buz.foo == 0)
+    assert (f.buz.bar.two['sub-two'] == 2)
+    assert (f.buz.bar.three == [3, 3, 3])
 
     f = Foo_1({'buz': {'foo': 3,
                        'bar': {'one': 11}}})
-    assert(f.buz.bar.one == 11)
-    assert(f.buz.bar.two['sub-two'] == 2)
+    assert (f.buz.bar.one == 11)
+    assert (f.buz.bar.two['sub-two'] == 2)
 
     f = Foo_1({'buz': {'foo': 3,
                        'bar': {'one': 0,
                                'two': {2: 22}}}})
     f.verify()  # method `verify` convert int into str according to the scheme
-    assert(f.buz.bar.two['2'] == 22)
+    assert (f.buz.bar.two['2'] == 22)
+
+    f = Foo_1()
+    # default values from Foo_1 class
+    assert (f.buz.bar['two'] == {'sub-two': 2})
+    assert (f.buz.bar['one'] == 1)
+    b = Bar_1()
+    f.update({'buz': {'bar': b}})
+    # default values from Bar_1 class
+    assert (f.buz.bar.three == [3, 3, 3])
+    assert (f.buz.bar['two'] == {'two-default': 0})
+    assert (f.buz.bar.get('one') is None)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/unittests/test_profiler.py
+++ b/tests/unittests/test_profiler.py
@@ -24,7 +24,8 @@ def _cmd(cmd):
 
     _, _, ret = ru.sh_callout(cmd)
 
-    return not bool(ret)
+    if ret == 0: return True
+    else       : return False
 
 
 # ------------------------------------------------------------------------------
@@ -45,6 +46,7 @@ def test_profiler():
         prof.prof('foo')
         prof.prof('bar', uid='baz')
         prof.prof('buz', ts=now)
+        prof.flush()
 
         assert(os.path.isfile(fname))
 
@@ -81,6 +83,7 @@ def test_env():
             prof  = ru.Profiler(name=pname, ns='radical.utils.test',
                                 path='/tmp/')
             prof.prof('foo')
+            prof.flush()
 
             assert(res == os.path.isfile(fname))
             assert(res == _cmd('grep -e "^[0-9\\.]*,foo,%s," %s'


### PR DESCRIPTION
This simplifies inheritance: the child class does not need to apply defaults on it's own, and then again apply the default dict, but both are now always applied (when set).