### PR TITLE
small plugin manager fixes

### DIFF
--- a/src/radical/utils/plugin_manager.py
+++ b/src/radical/utils/plugin_manager.py
@@ -166,6 +166,7 @@ class PluginManager(object):
 
                 modname = os.path.splitext(os.path.basename(pfile))[0]
                 try:
+                    # load and register the plugin
                     loader = imp_loader.SourceFileLoader(modname, pfile)
                     spec   = imp.spec_from_loader(loader.name, loader)
                     plugin = imp.module_from_spec(spec)

--- a/src/radical/utils/plugin_manager.py
+++ b/src/radical/utils/plugin_manager.py
@@ -188,11 +188,11 @@ class PluginManager(object):
                     spec   = imp.spec_from_file_location(modname, pfile)
                     plugin = imp.module_from_spec(spec)
                     spec.loader.exec_module(plugin)
-#
 
                     # get plugin details from description
                     ptype  = plugin.PLUGIN_DESCRIPTION.get('type',        None)
                     pname  = plugin.PLUGIN_DESCRIPTION.get('name',        None)
+                    pclass = plugin.PLUGIN_DESCRIPTION.get('class',       None)
                     pvers  = plugin.PLUGIN_DESCRIPTION.get('version',     None)
                     pdescr = plugin.PLUGIN_DESCRIPTION.get('description', None)
 
@@ -203,6 +203,10 @@ class PluginManager(object):
 
                     if not pname:
                         self._log.error('no plugin name in %s' % pshort)
+                        continue
+
+                    if not pclass:
+                        self._log.error('no plugin class in %s' % pshort)
                         continue
 
                     if not pvers:
@@ -222,7 +226,8 @@ class PluginManager(object):
                         self._log.warn('overloading plugin %s' % pshort)
 
                     self._plugins[ptype][pname] = {
-                        'class'      : plugin.PLUGIN_CLASS,
+                        'plugin'     : plugin,
+                        'class'      : pclass,
                         'type'       : ptype,
                         'name'       : pname,
                         'version'    : pvers,
@@ -297,8 +302,13 @@ class PluginManager(object):
             raise LookupError('No such plugin name %s (type: %s) in %s'
                     % (pname, ptype, list(self._plugins[ptype].keys())))
 
+
+        plugin = self._plugins[ptype][pname]['plugin']
+        pclass = self._plugins[ptype][pname]['class']
+        pinst  = getattr(plugin, pclass)()
+
         # create new plugin instance
-        return self._plugins[ptype][pname]['class']()
+        return pinst
 
 
     # --------------------------------------------------------------------------

--- a/src/radical/utils/plugins/unittests_1/plugin_unittests_default_1.py
+++ b/src/radical/utils/plugins/unittests_1/plugin_unittests_default_1.py
@@ -12,6 +12,7 @@ import does_not_exist as nope                       # noqa pylint: disable=F0401
 PLUGIN_DESCRIPTION = {
     'type'       : 'unittests_1',
     'name'       : 'default_1',
+    'class'      : 'PLUGIN_CLASS',
     'version'    : '0.1',
     'description': 'this is an empty test which basically does nothing.'
 }
@@ -32,7 +33,7 @@ class PLUGIN_CLASS(object, metaclass=ru.Singleton):
     def __init__(self):
 
         if PLUGIN_CLASS._created:
-            assert(False), 'singleton plugin should not get created twice'
+            assert(False), 'singleton plugin created twice'
 
         PLUGIN_CLASS._created = True
 

--- a/src/radical/utils/plugins/unittests_1/plugin_unittests_default_2.py
+++ b/src/radical/utils/plugins/unittests_1/plugin_unittests_default_2.py
@@ -11,6 +11,7 @@ import radical.utils as ru
 PLUGIN_DESCRIPTION = {
     'type'       : 'unittests_1',
     'name'       : 'default_2',
+    'class'      : 'PLUGIN_CLASS',
     'version'    : '0.1',
     'description': 'this is an empty test which basically does nothing.'
 }
@@ -31,7 +32,7 @@ class PLUGIN_CLASS(object, metaclass=ru.Singleton):
     def __init__(self):
 
         if PLUGIN_CLASS._created:
-            assert(False), 'singleton plugin should not get created twice'
+            assert(False), 'singleton plugin created twice'
 
         PLUGIN_CLASS._created = True
 

--- a/src/radical/utils/plugins/unittests_2/plugin_unittests_default_1.py
+++ b/src/radical/utils/plugins/unittests_2/plugin_unittests_default_1.py
@@ -12,6 +12,7 @@ import does_not_exist as nope                       # noqa pylint: disable=F0401
 PLUGIN_DESCRIPTION = {
     'type'       : 'unittests_2',
     'name'       : 'default_1',
+    'class'      : 'PLUGIN_CLASS',
     'version'    : '0.1',
     'description': 'this is an empty test which basically does nothing.'
 }
@@ -31,7 +32,7 @@ class PLUGIN_CLASS(object, metaclass=ru.Singleton):
     def __init__(self):
 
         if PLUGIN_CLASS._created:
-            assert(False), "singleton plugin should not get created twice"
+            assert(False), "singleton plugin created twice"
 
         PLUGIN_CLASS._created = True
 

--- a/src/radical/utils/plugins/unittests_2/plugin_unittests_default_2.py
+++ b/src/radical/utils/plugins/unittests_2/plugin_unittests_default_2.py
@@ -7,10 +7,11 @@ __license__   = 'MIT'
 # ------------------------------------------------------------------------------
 #
 PLUGIN_DESCRIPTION = {
-    'type'        : 'unittests_2',
-    'name'        : 'default_2',
-    'version'     : '0.1',
-    'description' : 'this is a test which basically does nothing.'
+    'type'       : 'unittests_2',
+    'name'       : 'default_2',
+    'class'      : 'PLUGIN_CLASS',
+    'version'    : '0.1',
+    'description': 'this is a test which basically does nothing.'
 }
 
 
@@ -32,7 +33,7 @@ class PLUGIN_CLASS(object):
     #
     def init(self, *args):
 
-        assert(self._args is None), 'plugin should get created twice'
+        assert(self._args is None), 'plugin created twice'
         self._args = args
 
 


### PR DESCRIPTION
This PR cleans the `PluginManager` code.  The biggest change should be that one can now name the plugin class freely, all else are just cosmetic changes.

The PM is now used in the exaworks API implementation, thus the update.