### PR TITLE
fixing deprecating method

### DIFF
--- a/src/radical/utils/futures.py
+++ b/src/radical/utils/futures.py
@@ -104,7 +104,7 @@ class Future(mt.Thread):
     #
     def wait(self, timeout=None):
 
-        if self.isAlive():
+        if self.is_alive():
             self.join(timeout=timeout)
 
 


### PR DESCRIPTION
Thread objects deprecated `isAlive` from python version 3.7 in favor of `is_alive`:
```
(base) iparask@js-17-185:$ conda create -n test python=3.7 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.isAlive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method is deprecated, use is_alive() instead.

(base) iparask@js-17-185:$ conda create -n test python=3.6 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.is_alive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method returns True just before the run() method starts until just
        after the run() method terminates. The module function enumerate()
        returns a list of all alive threads.

(base) iparask@js-17-185:$ conda create -n test python=3.5 -y;conda activate test;python -c 'import threading as mt;t = mt.Thread();print(t.is_alive.__doc__);exit();';conda deactivate;conda remove --all -n test -y

Return whether the thread is alive.

        This method returns True just before the run() method starts until just
        after the run() method terminates. The module function enumerate()
        returns a list of all alive threads.

(base) iparask@js-17-185:$
```

Method `is_alive` exists from python 3.5