### PR TITLE
fix munchification

### DIFF
--- a/src/radical/utils/config.py
+++ b/src/radical/utils/config.py
@@ -139,6 +139,8 @@ from .singleton  import Singleton
 #
 class Config(Munch):
 
+    _self_default = True
+
     # FIXME: we should cache config files after reading, so that repeated
     #        instance creations do not trigger a new (identical) round of
     #        parsing.

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -96,7 +96,7 @@ class Munch(DictMixin):
             if isinstance(v, dict):
                 t = self._schema.get(k)
                 if not t:
-                    t = type(self)
+                    t = Munch
                 if isinstance(t, type) and \
                         issubclass(t, Munch) and not issubclass(type(v), Munch):
                     # cast to expected Munch type

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -13,6 +13,7 @@
 
 import copy
 
+from .config     import Config
 from .misc       import as_list, as_tuple
 from .misc       import is_string
 from .misc       import expand_env as ru_expand_env
@@ -96,7 +97,10 @@ class Munch(DictMixin):
             if isinstance(v, dict):
                 t = self._schema.get(k)
                 if not t:
-                    t = Munch
+                    if type(self) == type(Config):
+                        t = Config
+                    else:
+                        t = Munch
                 if isinstance(t, type) and \
                         issubclass(t, Munch) and not issubclass(type(v), Munch):
                     # cast to expected Munch type

--- a/src/radical/utils/munch.py
+++ b/src/radical/utils/munch.py
@@ -13,7 +13,6 @@
 
 import copy
 
-from .config     import Config
 from .misc       import as_list, as_tuple
 from .misc       import is_string
 from .misc       import expand_env as ru_expand_env
@@ -24,6 +23,8 @@ from .json_io    import write_json
 # ------------------------------------------------------------------------------
 #
 class Munch(DictMixin):
+
+    _self_default = False
 
     # --------------------------------------------------------------------------
     #
@@ -97,10 +98,8 @@ class Munch(DictMixin):
             if isinstance(v, dict):
                 t = self._schema.get(k)
                 if not t:
-                    if type(self) == type(Config):
-                        t = Config
-                    else:
-                        t = Munch
+                    if self._self_default: t = type(self)
+                    else                 : t = Munch
                 if isinstance(t, type) and \
                         issubclass(t, Munch) and not issubclass(type(v), Munch):
                     # cast to expected Munch type

--- a/tests/unittests/test_config.py
+++ b/tests/unittests/test_config.py
@@ -37,6 +37,11 @@ def test_config():
     cfg4 = ru.Config(name=path, env=env)
     assert('baz' == cfg4.query('yale.grace.agent_launch_method'))
 
+    # test `cls._self_default` flag
+    cfg5 = ru.Config(from_dict={'foo_0': {'foo_1': {'foo2': 'bar'}}})
+    assert('bar' == cfg5.foo_0.foo_1.foo2)
+    assert(isinstance(cfg5.foo_0.foo_1, ru.Config))
+
 
 # ------------------------------------------------------------------------------
 #

--- a/tests/unittests/test_munch.py
+++ b/tests/unittests/test_munch.py
@@ -174,6 +174,27 @@ def test_munch_update():
     assert (f.buz.bar['two'] == {'two-default': 0})
     assert (f.buz.bar.get('one') is None)
 
+    # test `cls._self_default` flag (for method `update`)
+
+    # --------------------------------------------------------------------------
+    # cls._self_default is False
+    class Bar_2a(ru.Munch):
+        _self_default = False
+
+    # --------------------------------------------------------------------------
+    # cls._self_default is True
+    class Bar_2b(ru.Munch):
+        _self_default = True
+
+    # --------------------------------------------------------------------------
+    bar = Bar_2a(from_dict={'foo_0': {'foo_1': {'foo2': 'bar'}}})
+    assert (not isinstance(bar.foo_0, Bar_2a))
+    assert (isinstance(bar.foo_0.foo_1, ru.Munch))
+
+    bar = Bar_2b(from_dict={'foo_0': {'foo_1': {'foo2': 'bar'}}})
+    assert (isinstance(bar.foo_0, Bar_2b))
+    assert (issubclass(type(bar.foo_0.foo_1), ru.Munch))
+
 
 # ------------------------------------------------------------------------------
 #


### PR DESCRIPTION
This is needed by radical-cybertools/radical.pilot/pull/2287: if the type defaults to the top level type, then the initialization can recurse endlessly.  It also does not make sense to force all dict-like attributes of, say, a `PilotDescription` to be also of that type (`PilotDescription`) - it is sufficient to cast to `Munch`.  We make an exception for `ru.Config` types though, where that hierarchy makes sense.