### PR TITLE
Feature/stack ns

### DIFF
--- a/bin/radical-stack
+++ b/bin/radical-stack
@@ -4,33 +4,26 @@ import sys
 
 import radical.utils as ru
 
-verbose = False
-if len(sys.argv) > 1 and sys.argv[1] == '-v':
-    verbose = True
+namespaces = sys.argv[1:]
+if not namespaces:
+    namespaces = ['radical']
 
-stack = ru.stack()
+stack = ru.stack(namespaces)
 
 print()
 for key in sorted(stack['sys'].keys()):
     print('  %-20s : %s' % (key, stack['sys'][key]))
 print()
 
-for key in sorted(stack['radical'].keys()):
+for ns in stack:
+    if ns == 'sys':
+        continue
 
-    if verbose:
-        # get pip info for latest version available
-        out, _, _ = ru.sh_callout('python -m pip search %s' % key)
-        idx0 = out.find('(')
-        idx1 = out.find(')')
-        out  = out[idx0 + 1:idx1]
+    for key in sorted(stack[ns].keys()):
 
-        print('  %-20s : %-50s  (latest release: %s)'
-             % (key, stack['radical'][key], out))
+        print('  %-20s : %s' % (key, stack[ns][key]))
 
-    else:
-        print('  %-20s : %s' % (key, stack['radical'][key]))
-
-print()
+    print()
 
 # ------------------------------------------------------------------------------
 

--- a/src/radical/utils/__init__.py
+++ b/src/radical/utils/__init__.py
@@ -42,6 +42,7 @@ from .testing        import sys_exit
 from .testing        import TestConfig
 from .testing        import set_test_config, add_test_config, get_test_config
 from .env            import env_prep, env_read, env_read_lines, env_diff
+from .stack          import stack
 
 from .zmq            import Bridge
 from .zmq            import Queue,  Putter,    Getter

--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -757,55 +757,6 @@ def expand_env(data, env=None, ignore_missing=True):
 
 # ------------------------------------------------------------------------------
 #
-def stack():
-    '''
-    returns a dict with information about the currently active python
-    interpreter and all radical modules (incl. version details)
-    '''
-
-    ret = {'sys'     : {'python'     : sys.version.split()[0],
-                        'pythonpath' : os.environ.get('PYTHONPATH',  ''),
-                        'virtualenv' : os.environ.get('VIRTUAL_ENV', '') or
-                                       os.environ.get('CONDA_DEFAULT_ENV','')},
-           'radical' : dict()
-          }
-
-    import radical
-    path = radical.__path__
-    if isinstance(path, list):
-        path = path[0]
-
-    if isinstance(path, str):
-        rpath = path
-    else:
-        rpath = path._path                               # pylint: disable=W0212
-
-    if isinstance(rpath, list):
-        rpath = rpath[0]
-
-    for mpath in glob.glob('%s/*' % rpath):
-
-        if os.path.isdir(mpath):
-
-            mbase = os.path.basename(mpath)
-            mname = 'radical.%s' % mbase
-
-            if mbase.startswith('_'):
-                continue
-
-            try:
-                ret['radical'][mname] = import_module(mname).version_detail
-            except Exception as e:
-                if 'RADICAL_DEBUG' in os.environ:
-                    ret['radical'][mname] = str(e)
-                else:
-                    ret['radical'][mname] = '?'
-
-    return ret
-
-
-# ------------------------------------------------------------------------------
-#
 def get_size(obj, seen=None, strict=False):
 
     size   = sys.getsizeof(obj)

--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -1,20 +1,25 @@
 
 import os
 import sys
-import glob
 import time
 import errno
 import socket
 import tarfile
 import datetime
 import tempfile
-import importlib
 import itertools
 import netifaces
 
 from .         import url       as ruu
-from .modules  import import_module
 from .ru_regex import ReString
+
+
+# ------------------------------------------------------------------------------
+#
+_RU_stdout = None
+_RU_stderr = None
+_RU_except = None
+_RU_exit   = None
 
 
 # ------------------------------------------------------------------------------
@@ -992,7 +997,7 @@ def script_2_func(fpath):
                  + ''.join(postfix)
 
         # exec the resulting code, ensure to pass globals
-        exec(tmp_code, globals())
+        exec(tmp_code, globals())                        # pylint: disable=W0122
 
         return _RU_stdout.getvalue(), _RU_stderr.getvalue(), \
                _RU_except, _RU_exit

--- a/src/radical/utils/stack.py
+++ b/src/radical/utils/stack.py
@@ -54,7 +54,7 @@ def stack(ns='radical'):
                 try:
                     ret[namespace][mname] = import_module(mname).version_detail
                 except Exception as e:
-                    if '%s_DEBUG' % ns.upper() in os.environ:
+                    if '%s_DEBUG' % namespace.upper() in os.environ:
                         ret[namespace][mname] = str(e)
                     else:
                         ret[namespace][mname] = '?'

--- a/src/radical/utils/stack.py
+++ b/src/radical/utils/stack.py
@@ -54,7 +54,7 @@ def stack(ns='radical'):
                 try:
                     ret[namespace][mname] = import_module(mname).version_detail
                 except Exception as e:
-                    if 'RADICAL_DEBUG' in os.environ:
+                    if '%s_DEBUG' % ns.upper() in os.environ:
                         ret[namespace][mname] = str(e)
                     else:
                         ret[namespace][mname] = '?'

--- a/src/radical/utils/stack.py
+++ b/src/radical/utils/stack.py
@@ -30,7 +30,6 @@ def stack(ns='radical'):
 
         ns_mod = import_module(namespace)
         path   = ns_mod.__path__
-        print(path)
         if isinstance(path, list):
             path = path[0]
 

--- a/src/radical/utils/stack.py
+++ b/src/radical/utils/stack.py
@@ -1,0 +1,62 @@
+
+import os
+import sys
+import glob
+
+from .shell   import sh_callout
+from .modules import import_module
+
+
+# ------------------------------------------------------------------------------
+#
+def stack():
+    '''
+    returns a dict with information about the currently active python
+    interpreter and all radical modules (incl. version details)
+    '''
+
+    exe = sh_callout('which python3', shell=True)[0].strip()
+    ret = {'sys'     : {'python'     : exe,
+                        'version'    : sys.version.split()[0],
+                        'pythonpath' : os.environ.get('PYTHONPATH',  ''),
+                        'virtualenv' : os.environ.get('VIRTUAL_ENV', '') or
+                                       os.environ.get('CONDA_DEFAULT_ENV','')},
+           'radical' : dict()
+          }
+
+    import radical
+    path = radical.__path__
+    if isinstance(path, list):
+        path = path[0]
+
+    if isinstance(path, str):
+        rpath = path
+    else:
+        rpath = path._path                               # pylint: disable=W0212
+
+    if isinstance(rpath, list):
+        rpath = rpath[0]
+
+    for mpath in glob.glob('%s/*' % rpath):
+
+        if os.path.isdir(mpath):
+
+            mbase = os.path.basename(mpath)
+            mname = 'radical.%s' % mbase
+
+            if mbase.startswith('_'):
+                continue
+
+            try:
+                ret['radical'][mname] = import_module(mname).version_detail
+            except Exception as e:
+                if 'RADICAL_DEBUG' in os.environ:
+                    ret['radical'][mname] = str(e)
+                else:
+                    ret['radical'][mname] = '?'
+
+    return ret
+
+
+# ------------------------------------------------------------------------------
+

--- a/tests/unittests/test_stack.py
+++ b/tests/unittests/test_stack.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+__author__    = 'RADICAL-Cybertools Team'
+__copyright__ = 'Copyright 2021, The RADICAL-Cybertools Team'
+__license__   = 'MIT'
+
+import os
+import shutil
+
+import radical.utils as ru
+
+from unittest import TestCase
+
+
+# ------------------------------------------------------------------------------
+#
+class StackTestClass(TestCase):
+
+    # --------------------------------------------------------------------------
+    #
+    @classmethod
+    def setUpClass(cls):
+        ns_mod               = ru.import_module('radical')
+        cls._radical_ns_dir = ns_mod.__path__._path[0]
+        # create a directory inside "radical" namespace (false package)
+        ru.rec_makedir(cls._radical_ns_dir + '/dummy')
+
+    # --------------------------------------------------------------------------
+    #
+    @classmethod
+    def tearDownClass(cls):
+        # delete false package
+        try:
+            shutil.rmtree(cls._radical_ns_dir + '/dummy')
+        except OSError as e:
+            print('[ERROR] %s - %s' % (e.filename, e.strerror))
+
+    # --------------------------------------------------------------------------
+    #
+    def test_stack(self):
+
+        # - "radical" namespace (default) -
+        stack_output = ru.stack()
+        self.assertIn('sys', stack_output)
+        self.assertIn('radical', stack_output)
+        for module in ['pilot', 'saga', 'utils']:
+            self.assertIn('radical.%s' % module, stack_output['radical'])
+        self.assertEqual(stack_output['radical']['radical.dummy'], '?')
+
+        os.environ['RADICAL_DEBUG'] = 'TRUE'
+        stack_output = ru.stack()
+        self.assertTrue(stack_output['radical']['radical.dummy'].endswith(
+            "no attribute 'version_detail'"))
+
+        # - "requests" - not a namespace, but a package-
+        stack_output = ru.stack(ns=['radical', 'requests'])
+        self.assertFalse(stack_output['requests'])
+
+        # - non existed namespace/package -
+        with self.assertRaises(ModuleNotFoundError):
+            _ = ru.stack(ns='no_valid_pkg')
+
+# ------------------------------------------------------------------------------

--- a/tests/unittests/test_stack.py
+++ b/tests/unittests/test_stack.py
@@ -20,7 +20,7 @@ class StackTestClass(TestCase):
     #
     @classmethod
     def setUpClass(cls):
-        ns_mod               = ru.import_module('radical')
+        ns_mod              = ru.import_module('radical')
         cls._radical_ns_dir = ns_mod.__path__._path[0]
         # create a directory inside "radical" namespace (false package)
         ru.rec_makedir(cls._radical_ns_dir + '/dummy')


### PR DESCRIPTION
generalize the stack query to support other name spaces than just `radical`.

Alas, this PR also removes the `-v` flag from `radical-stack`, as pip does not support the respective query anymore.  We need to look for an alternative way to implement this (related to radical-cybertools/radical.entk/issues/476)