### PR TITLE
capture current env

### DIFF
--- a/bin/radical-utils-env.sh
+++ b/bin/radical-utils-env.sh
@@ -88,8 +88,10 @@ env_prep(){
 
     if test -z "$src"
     then
-        echo "missing 'src' to prepare env from"
-        return 1
+        echo "missing 'src' -- prepare env from current env"
+        tmp=$(mktemp)
+        env > "$tmp"
+        src="$tmp"
     fi
 
     # get keys from `src` environment dump
@@ -157,8 +159,10 @@ env_prep(){
 
     env=$(_prep)
 
-    test -z "$tgt" && echo "$env"
-    test -z "$tgt" || echo "$env" > $tgt
+    test -z "$tgt" && echo  "$env"
+    test -z "$tgt" || echo  "$env" > $tgt
+
+    test -z "$tmp" || rm -f "$tmp"
 }
 
 


### PR DESCRIPTION
Small change to `prep_env` to default to the environment the method is called in (instead of requiring a captured source environment)