### PR TITLE
make profiler fork-save

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        paths:
+          - "src"
+
+
+github_checks:
+  annotations: false
+

--- a/src/radical/utils/profile.py
+++ b/src/radical/utils/profile.py
@@ -132,9 +132,7 @@ def _atfork_child():
         prof._handle = open(fname, 'a', buffering=1024)
 
 
-# lock cleaning can be disabled by setting RADICAL_UTILS_NO_ATFORK
-if 'RADICAL_UTILS_NO_ATFORK' not in os.environ:
-    atfork(_atfork_prepare, _atfork_parent, _atfork_child)
+atfork(_atfork_prepare, _atfork_parent, _atfork_child)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
```
# The profiler is not using threads and is generally threadsafe (all write ops
# should be atomic) - but alas Python threadlocks I/O streams, and those locks
# can still deadlock after fork
#
#   - https://bugs.python.org/issue6721
#   - https://bugs.python.org/issue40399
#
# We thus have to close/reopen the prof file handle after fork.  This creates
# a bit of a mess as we not have to maintain a global list of profiler instances
# to clean up after fork... :-/
```