### PR TITLE
handling encoded string for mongodb password

### DIFF
--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -10,9 +10,10 @@ import tempfile
 import itertools
 import netifaces
 
+from urllib.parse import unquote_plus
+
 from .         import url       as ruu
 from .ru_regex import ReString
-from urllib.parse import quote_plus, unquote_plus
 
 # ------------------------------------------------------------------------------
 #
@@ -113,6 +114,7 @@ def mongodb_connect(dburl, default_dburl=None):
 
     try:
         import pymongo
+
     except ImportError as e:
         msg  = " \n\npymongo is not available -- install RU with: \n\n"
         msg += "  (1) pip install --upgrade -e '.[pymongo]'\n"

--- a/src/radical/utils/misc.py
+++ b/src/radical/utils/misc.py
@@ -12,6 +12,7 @@ import netifaces
 
 from .         import url       as ruu
 from .ru_regex import ReString
+from urllib.parse import quote_plus, unquote_plus
 
 # ------------------------------------------------------------------------------
 #
@@ -57,7 +58,7 @@ def split_dburl(dburl, default_dburl=None):
     port = url.port
     path = url.path
     user = url.username
-    pwd  = url.password
+    pwd  = unquote_plus(url.password)
 
     query_options = {'ssl': False}
 


### PR DESCRIPTION
According to [this](https://docs.mongodb.com/manual/reference/connection-string/), special characters are allowed with encoding in the URI format, and it has to be parsed before returning DB information. If it is a normal string then the `unquote_plus` doesn't do anything, keep the original string.