### PR TITLE
Update host.py

### DIFF
--- a/src/radical/utils/host.py
+++ b/src/radical/utils/host.py
@@ -114,7 +114,7 @@ def create_hostfile(sandbox, name, hostlist, sep=' ', impaired=False):
 
     hostlist = as_list(hostlist)
     filename = '%s/%s.hosts' % (sandbox or '.', name)
-    with open(filename, 'w') as fout:
+    with open(filename, 'w', encoding='utf8') as fout:
 
         if not impaired:
             # create dict: {'host1': x, 'host2': y}

--- a/src/radical/utils/host.py
+++ b/src/radical/utils/host.py
@@ -24,12 +24,7 @@ def get_hostname():
     global _hostname                                     # pylint: disable=W0603
     if not _hostname:
 
-        _hostname = socket.gethostname()
-        if '.' in _hostname:
-            try:
-                _hostname = socket.gethostbyaddr(_hostname)[0]
-            except socket.herror:
-                pass
+        _hostname = socket.getfqdn()
 
     return _hostname
 

--- a/tests/unittests/test_host.py
+++ b/tests/unittests/test_host.py
@@ -77,7 +77,7 @@ class HostTestCase(TestCase):
 
             filename = ru.create_hostfile(self._base_dir, 'tc', hostlist, sep)
 
-            with open(filename) as f:
+            with open(filename, 'r', encoding='utf8') as f:
                 hostfile_lines = f.readlines()
             self.assertEqual(test_case['result']['lines'], hostfile_lines)
 


### PR DESCRIPTION
There seemed to be unnecessary logic in host.py that wouldn't work quite right,
at least for nested local hostnames.

Checking whether there is a '.' in the hostname doesn't really tell anything,
so maybe I have misunderstood the intention. However, `getfqdn()` has a
reasonable return value with various fall-back logic the makes an exception
unlikely.

Note that on MacOS, `socket.gethostbyaddr(socket.gethostname())`
is likely to raise `socket.gaierror` rather than `socket.herror`.

If this function is used for more than logging, (to determine something about the
connection between RCT components), I would think that it would be more
effective to create a trial socket and inspect it.
(E.g. `socket.create_connection(...).getsockname()`)
But I think `host.get_hostip()` is used for that sort of thing.