### PR TITLE
only unset superfluous env vars on `env_write`

### DIFF
--- a/src/radical/utils/env.py
+++ b/src/radical/utils/env.py
@@ -63,6 +63,8 @@ def env_write(script_path, env, unset=None, pre_exec=None):
     if unset:
         data += '# unset\n'
         for k in sorted(unset):
+            if k in env:
+                continue
             if not re_snake_case.match(k):
                 continue
             data += 'unset %s\n' % k


### PR DESCRIPTION
@AymenFJA : this fix should resolve https://github.com/radical-cybertools/radical.pilot/issues/2489 - please give it a try.  Thanks!