### PR TITLE
Fixed conda deactivate (`env_deactivate`)

### DIFF
--- a/bin/radical-utils-env.sh
+++ b/bin/radical-utils-env.sh
@@ -353,6 +353,7 @@ env_deactivate(){
     conda=$(which conda 2>/dev/null)
     if ! test -z "$conda"
     then
+        eval "$(conda shell.posix hook)"
         while test "$CONDA_SHLVL" -gt "0"
         do
             conda deactivate


### PR DESCRIPTION
Finalize conda initialization before any conda calls (even if conda env variables are set, we should ensure that conda is initialized)