### PR TITLE
Remove RG (`radical.gtod`) from the dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,6 @@ setup_args = {
                             'ntplib',
                             'pymongo<4',
                             'pyzmq',
-                            'radical.gtod',
                             'regex',
                             'setproctitle',
                            ],


### PR DESCRIPTION
RG is required for RP (see RP PR [#2571](https://github.com/radical-cybertools/radical.pilot/pull/2571))