### PR TITLE
fix and simplify registry path traversal

### DIFF
--- a/src/radical/utils/zmq/registry.py
+++ b/src/radical/utils/zmq/registry.py
@@ -75,8 +75,6 @@ class Registry(Server):
     #
     def get(self, key: str) -> Optional[str]:
 
-        self._log.debug('==== get %s', key)
-
         this  = self._data
         elems = key.split('.')
         path  = elems[:-1]

--- a/src/radical/utils/zmq/registry.py
+++ b/src/radical/utils/zmq/registry.py
@@ -55,15 +55,17 @@ class Registry(Server):
 
         this  = self._data
         elems = key.split('.')
+        path  = elems[:-1]
+        leaf  = elems[-1]
 
-        for elem in elems[:-1]:
-            step = this.get(elem)
-            if step is None:
-                step = dict()
-                this[elem] = step
-                this = this[elem]
+        for elem in path:
 
-        this[elems[-1]] = val
+            if elem not in this:
+                this[elem] = dict()
+
+            this = this[elem]
+
+        this[leaf] = val
 
         if not isinstance(self._data, dict):
             self._data.sync()
@@ -73,20 +75,20 @@ class Registry(Server):
     #
     def get(self, key: str) -> Optional[str]:
 
-        try:
-            this  = self._data
-            elems = key.split('.')
-            for elem in elems[:-1]:
-                step = this.get(elem)
-                if step is None:
-                    return None
-                this = step
+        self._log.debug('==== get %s', key)
 
-            ret = this.get(elems[-1])
-            return ret
+        this  = self._data
+        elems = key.split('.')
+        path  = elems[:-1]
+        leaf  = elems[-1]
 
-        except AttributeError:
-            return None
+        for elem in path:
+
+            this = this.get(elem)
+            if not this:
+                return None
+
+        return this.get(leaf)
 
 
     # --------------------------------------------------------------------------

--- a/tests/unittests/test_zmq_registry.py
+++ b/tests/unittests/test_zmq_registry.py
@@ -20,6 +20,12 @@ def test_zmq_registry(mocked_prof):
         assert r.addr
         c = ru.zmq.RegistryClient(url=r.addr)
 
+        c.put('foo.bar.buz', {'biz': 11})
+        assert c.get('foo') == {'bar': {'buz': {'biz': 11}}}
+        assert c.get('foo.bar.buz.biz') == 11
+        assert c.get('foo.bar.buz.biz.boz') is None
+        assert c.get('foo') == {'bar': {'buz': {'biz': 11}}}
+
         c.put('foo.bar.buz', {'biz': 42})
         assert c.get('foo') == {'bar': {'buz': {'biz': 42}}}
         assert c.get('foo.bar.buz.biz') == 42

--- a/tests/unittests/test_zmq_registry.py
+++ b/tests/unittests/test_zmq_registry.py
@@ -27,10 +27,7 @@ def test_zmq_registry(mocked_prof):
         assert c.get('foo') == {'bar': {'buz': {'biz': 11}}}
 
         c.put('foo.bar.buz', {'biz': 42})
-        assert c.get('foo') == {'bar': {'buz': {'biz': 42}}}
         assert c.get('foo.bar.buz.biz') == 42
-        assert c.get('foo.bar.buz.biz.boz') is None
-        assert c.get('foo') == {'bar': {'buz': {'biz': 42}}}
 
         assert c['foo.bar.buz.biz'] == 42
         assert c['foo']['bar']['buz']['biz'] == 42


### PR DESCRIPTION
The important change is on the `put()` method where the line `this = this[elem]` needed to be de-indented.  The original code failed when adding keys to an existing entry - the keys were placed in root instead.