### PR TITLE
fix deprecated import statement and inspect call

### DIFF
--- a/src/radical/utils/signatures.py
+++ b/src/radical/utils/signatures.py
@@ -172,9 +172,9 @@ if 'RADICAL_DEBUG_SIG' in os.environ:
 # ------------------------------------------------------------------------------
 
 from traceback import extract_stack
-from inspect   import getargspec, isclass
 from re        import compile as regex
 from functools import wraps
+from inspect   import getfullargspec, isclass
 
 # NOTE: Python 3: type NoneType does not exist anymore. Test against None.
 # from types     import NoneType
@@ -505,7 +505,7 @@ def takes(*args, **kwargs):
 
         def takes_proxy(method):
 
-            method_args, method_defaults = getargspec(method)[0::3]
+            method_args, method_defaults = getfullargspec(method)[0::3]
 
             @wraps(method)
             def signature_check(*pargs, **pkwargs):


### PR DESCRIPTION
Import now works for older and newer python3 versions:
```sh

  python               : /mnt/home/merzky/radical/radical.utils.2/ve3.6/bin/python3
  pythonpath           : 
  version              : 3.6.9
  virtualenv           : /mnt/home/merzky/radical/radical.utils.2/ve3.6

  radical.utils        : 1.22.0-v1.21.0-2-g585b3c4@fix-getargspec_import

```
```sh

  python               : /mnt/home/merzky/radical/radical.utils.2/ve3/bin/python3
  pythonpath           : 
  version              : 3.11.2
  virtualenv           : /mnt/home/merzky/radical/radical.utils.2/ve3

  radical.utils        : 1.22.0-v1.21.0-2-g585b3c4@fix-getargspec_import

```