### PR TITLE
nices and more informative warning on logging import order

### DIFF
--- a/src/radical/utils/atfork/stdlib_fixer.py
+++ b/src/radical/utils/atfork/stdlib_fixer.py
@@ -92,9 +92,8 @@ def fix_logging_module():
         # these exist, other loggers or not yet added handlers could as well.
         # Its safer to insist that this fix is applied before logging has been
         # configured.
-        _warn('Import `radical.utils` before `logging` to avoid the '
+        _warn('Import `radical` modules before `logging` to avoid the '
               'application to deadlock on `fork()`!')
-      # raise Error('logging handlers already registered.')
 
     logging._acquireLock()
     try:

--- a/src/radical/utils/atfork/stdlib_fixer.py
+++ b/src/radical/utils/atfork/stdlib_fixer.py
@@ -43,15 +43,33 @@ In 2.4.5 the following additional stdlib modules use locks:
 
 import os
 import sys
-import warnings
 
 from .atfork import atfork
 
 
+# ------------------------------------------------------------------------------
+#
+def _warn(msg):
+
+    import warnings
+
+    def custom_formatwarning(msg, *args, **kwargs):
+        return 'WARNING: %s\n' % str(msg)
+
+    orig_formatwarning     = warnings.formatwarning
+    warnings.formatwarning = custom_formatwarning
+    warnings.warn(msg)
+    warnings.formatwarning = orig_formatwarning
+
+
+# ------------------------------------------------------------------------------
+#
 class Error(Exception):
     pass
 
 
+# ------------------------------------------------------------------------------
+#
 def fix_logging_module():
 
     # monkeypatching can be disabled by setting RADICAL_UTILS_NO_ATFORK
@@ -74,7 +92,8 @@ def fix_logging_module():
         # these exist, other loggers or not yet added handlers could as well.
         # Its safer to insist that this fix is applied before logging has been
         # configured.
-        warnings.warn('logging handlers already registered.')
+        _warn('Import `radical.utils` before `logging` to avoid the '
+              'application to deadlock on `fork()`!')
       # raise Error('logging handlers already registered.')
 
     logging._acquireLock()


### PR DESCRIPTION
This results in the following:

```sh
$ python3 -c 'import logging; logging.error("foo"); import radical.utils'

ERROR:root:foo
WARNING: Import `radical.utils` before `logging` to avoid the application to deadlock on `fork()`!

```