### PR TITLE
Clean up the RST doctree.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,14 +20,7 @@ Contents:
    :numbered:
    :maxdepth: 2
 
-   modules.rst
-   utils.atfork.rst
-   utils.contrib.rst
-   utils.plugins.rst
-   utils.queue_network.rst
-   utils.rst
-   utils.scheduler.rst
-   utils.zmq.rst
+   utils
 
 
 ##################
@@ -37,4 +30,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,7 +1,0 @@
-radical
-=======
-
-.. toctree::
-   :maxdepth: 4
-
-   utils

--- a/docs/source/utils.atfork.rst
+++ b/docs/source/utils.atfork.rst
@@ -1,8 +1,11 @@
+============================
 radical.utils.atfork package
 ============================
 
+.. py:module:: radical.utils.atfork
+
 Submodules
-----------
+==========
 
 radical.utils.atfork.atfork module
 ----------------------------------
@@ -19,12 +22,3 @@ radical.utils.atfork.stdlib\_fixer module
    :members:
    :undoc-members:
    :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils.atfork
-   :members:
-   :undoc-members:
-   :show-inheritance:
-

--- a/docs/source/utils.contrib.rst
+++ b/docs/source/utils.contrib.rst
@@ -1,21 +1,16 @@
+=============================
 radical.utils.contrib package
 =============================
 
+.. py:module:: radical.utils.contrib
+
 Submodules
-----------
+==========
 
 radical.utils.contrib.urlparse25 module
 ---------------------------------------
 
 .. automodule:: radical.utils.contrib.urlparse25
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils.contrib
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/utils.plugins.rst
+++ b/docs/source/utils.plugins.rst
@@ -1,16 +1,11 @@
+=====================
 utils.plugins package
 =====================
 
+.. py:module:: radical.utils.plugins
+
 Subpackages
------------
+===========
 
 .. toctree::
    :maxdepth: 4
-
-Module contents
----------------
-
-.. automodule:: radical.utils.plugins
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/utils.queue_network.rst
+++ b/docs/source/utils.queue_network.rst
@@ -1,8 +1,11 @@
+============================
 utils.queue\_network package
 ============================
 
+.. py:module:: radical.utils.queue_network
+
 Submodules
-----------
+==========
 
 radical.utils.queue\_network.network module
 -------------------------------------------
@@ -24,14 +27,6 @@ radical.utils.queue\_network.queue module
 -----------------------------------------
 
 .. automodule:: radical.utils.queue_network.queue
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils.queue_network
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -1,8 +1,11 @@
+=====================
 radical.utils package
-=============--------
+=====================
+
+.. py:module:: radical.utils
 
 Subpackages
------------
+===========
 
 .. toctree::
    :maxdepth: 4
@@ -15,7 +18,7 @@ Subpackages
    utils.zmq
 
 Submodules
-----------
+==========
 
 radical.utils.algorithms module
 -------------------------------
@@ -317,14 +320,6 @@ radical.utils.which module
 --------------------------
 
 .. automodule:: radical.utils.which
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/utils.scheduler.rst
+++ b/docs/source/utils.scheduler.rst
@@ -1,8 +1,11 @@
+=======================
 utils.scheduler package
 =======================
 
+.. py:module:: radical.utils.scheduler
+
 Submodules
-----------
+==========
 
 radical.utils.scheduler.scheduler\_base module
 ----------------------------------------------
@@ -16,14 +19,6 @@ radical.utils.scheduler.scheduler\_bitarray module
 --------------------------------------------------
 
 .. automodule:: radical.utils.scheduler.scheduler_bitarray
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils.scheduler
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/utils.zmq.rst
+++ b/docs/source/utils.zmq.rst
@@ -1,8 +1,11 @@
+=================
 utils.zmq package
 =================
 
+.. py:module:: radical.utils.zmq
+
 Submodules
-----------
+==========
 
 radical.utils.zmq.bridge module
 -------------------------------
@@ -59,12 +62,3 @@ radical.utils.zmq.utils module
    :members:
    :undoc-members:
    :show-inheritance:
-
-Module contents
----------------
-
-.. automodule:: radical.utils.zmq
-   :members:
-   :undoc-members:
-   :show-inheritance:
-


### PR DESCRIPTION
This change addresses several issues:
* Several docs are included multiple times.
* Several autodoc directives are duplicated.
* Subpackages do not have effective base module documentation targets.

To deduplicate documentation, the doctree is simply flattened a bit, though section delimiters are adjusted to better represent the document hierarchy.

Since there is no docstring for most packages (`__index__.py` files), the `automodule` directive didn't do anything, and is replaced with a static module directive in the rst document.

Ref #375