### PR TITLE
prefer infiniband over ethernet

### DIFF
--- a/src/radical/utils/host.py
+++ b/src/radical/utils/host.py
@@ -55,6 +55,7 @@ def get_hostip(req=None, log=None):
     req = as_list(req)
 
     white_list = [
+        'ib0',      # infiniband (e.g., Amarel)
         'hsn0',     # Frontier (HPE Cray EX)
         'ipogif0',  # Cray's
         'br0',      # SuperMIC


### PR DESCRIPTION
This patch will let RU prefer )the first) infiniband interface over other (ethernet) interfaces. 