### PR TITLE
ensure `version_detail` is not `None`

### DIFF
--- a/src/radical/utils/get_version.py
+++ b/src/radical/utils/get_version.py
@@ -72,6 +72,9 @@ def get_version(paths=None):
         raise RuntimeError("Cannot determine version from %s (%s)"
                           % (paths, err.strip()))
 
+    if version_detail is None:
+        version_detail = version_short
+
     return (version_short, version_base, version_branch,
             version_tag, version_detail)
 


### PR DESCRIPTION
This fixes radical-cybertools/radical.pilot/issues/3228.