### PR TITLE
add callbacks to pulling end of pipe

### DIFF
--- a/src/radical/utils/debug.py
+++ b/src/radical/utils/debug.py
@@ -339,8 +339,8 @@ def attach_pudb(log=None):
 
     if log:
         log.info('debugger open: telnet %s %d', host, port)
-    else:
-        print('debugger open: telnet %s %d' % (host, port))
+
+    print('debugger open: telnet %s %d' % (host, port))
 
     try:
         import pudb                                      # pylint: disable=E0401
@@ -352,7 +352,9 @@ def attach_pudb(log=None):
 
     except Exception as e:
         if log:
-            log.warning('failed to attach pudb (%s)', e)
+            log.exception('failed to attach pudb')
+        else:
+            print('failed to attach pudb (%s)' % repr(e))
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/utils/zmq/pipe.py
+++ b/src/radical/utils/zmq/pipe.py
@@ -53,6 +53,7 @@ class Pipe(object):
         self._poller   = zmq.Poller()
         self._cbs      = list()
         self._listener = None
+        self._term     = mt.Event()
 
         if mode == MODE_PUSH:
             self._connect_push(url)
@@ -146,7 +147,7 @@ class Pipe(object):
         Listen for incoming messages, and call registered callbacks.
         '''
 
-        while True:
+        while not self._term.is_set():
 
             socks = dict(self._poller.poll(timeout=10))
 
@@ -202,6 +203,13 @@ class Pipe(object):
 
         if self._sock in socks:
             return from_msgpack(self._sock.recv())
+
+
+    # --------------------------------------------------------------------------
+    #
+    def stop(self):
+
+        self._term.set()
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/utils/zmq/pubsub.py
+++ b/src/radical/utils/zmq/pubsub.py
@@ -10,9 +10,7 @@ from typing      import Optional
 from ..atfork    import atfork
 from ..config    import Config
 from ..ids       import generate_id, ID_CUSTOM
-from ..url       import Url
 from ..misc      import as_string, as_bytes, as_list, noop
-from ..host      import get_hostip
 from ..logger    import Logger
 from ..profile   import Profiler
 from ..serialize import to_msgpack, from_msgpack
@@ -410,6 +408,7 @@ class Subscriber(object):
                       args=[self._sock, lock, term, callbacks,
                             self._log, self._prof])
         t.daemon = True
+        print('=== create pubsub listener %s' % t)
         t.start()
 
         self._thread = t

--- a/src/radical/utils/zmq/pubsub.py
+++ b/src/radical/utils/zmq/pubsub.py
@@ -228,8 +228,8 @@ class Publisher(object):
 
         assert isinstance(topic, str), 'invalid topic type'
 
-        self._log.debug_9('=== put %s : %s: %s', topic, self.channel, msg)
-      # self._log.debug_9('=== put %s: %s', msg, get_stacktrace())
+        self._log.debug_9('put %s : %s: %s', topic, self.channel, msg)
+      # self._log.debug_9('put %s: %s', msg, get_stacktrace())
       # self._prof.prof('put', uid=self._uid, msg=msg)
         log_bulk(self._log, '-> %s' % topic, [msg])
 
@@ -450,7 +450,7 @@ class Subscriber(object):
         log_bulk(self._log, '~~2 %s' % topic, [topic])
 
         with self._lock:
-            self._log.debug_9('==== subscribe for %s', topic)
+            self._log.debug_9('subscribe for %s', topic)
             no_intr(self._sock.setsockopt, zmq.SUBSCRIBE, as_bytes(topic))
 
         if topic not in self._topics:

--- a/src/radical/utils/zmq/queue.py
+++ b/src/radical/utils/zmq/queue.py
@@ -403,7 +403,7 @@ class Getter(object):
 
                 # send the request *once* per recieval (got lock above)
                 # FIXME: why is this sent repeatedly?
-                logger.debug_9('=== => from %s[%s]', uid, qname)
+                logger.debug_9('=> from %s[%s]', uid, qname)
                 no_intr(info['socket'].send, as_bytes(qname))
                 info['requested'] = True
 
@@ -499,7 +499,6 @@ class Getter(object):
 
         t = mt.Thread(target=Getter._listener, args=[self._url, qname, self._uid])
         t.daemon = True
-        print('=== create queue  listener %s' % t)
         t.start()
 
         Getter._callbacks[self._url]['thread'] = t
@@ -673,7 +672,7 @@ class Getter(object):
         if not self._requested:
             with self._lock:
                 if not self._requested:
-                    self._log.debug_9('=== => from %s[%s]', self._channel, qname)
+                    self._log.debug_9('=> from %s[%s]', self._channel, qname)
                     no_intr(self._q.send, as_bytes(qname))
                     self._requested = True
 
@@ -709,7 +708,7 @@ class Getter(object):
         if not self._requested:
             with self._lock:  # need to protect self._requested
                 if not self._requested:
-                    self._log.debug_9('=== => from %s[%s]', self._channel, qname)
+                    self._log.debug_9('=> from %s[%s]', self._channel, qname)
                     no_intr(self._q.send_multipart, [as_bytes(qname)])
                     self._requested = True
 

--- a/src/radical/utils/zmq/queue.py
+++ b/src/radical/utils/zmq/queue.py
@@ -11,9 +11,7 @@ from typing      import Optional
 from ..atfork    import atfork
 from ..config    import Config
 from ..ids       import generate_id, ID_CUSTOM
-from ..url       import Url
-from ..misc      import as_string, as_bytes, as_list, noop, find_port
-from ..host      import get_hostip
+from ..misc      import as_string, as_bytes, as_list, noop
 from ..logger    import Logger
 from ..profile   import Profiler
 from ..debug     import print_exception_trace
@@ -501,6 +499,7 @@ class Getter(object):
 
         t = mt.Thread(target=Getter._listener, args=[self._url, qname, self._uid])
         t.daemon = True
+        print('=== create queue  listener %s' % t)
         t.start()
 
         Getter._callbacks[self._url]['thread'] = t

--- a/src/radical/utils/zmq/utils.py
+++ b/src/radical/utils/zmq/utils.py
@@ -129,7 +129,7 @@ def get_channel_url(ep_type, channel=None, url=None):
 #
 def log_bulk(log, token, msgs):
 
-    if log._num_level > 1:
+    if log.num_level > 1:
         # log level `debug_9` disabled
         return
 


### PR DESCRIPTION
This PR adds callbacks to the pull end of a pipe.  That is used in RP to efficiently implement component startup checks.

The PR also cleans up some log messages and improves thread termination.