### PR TITLE
add comment on process group killing

### DIFF
--- a/src/radical/utils/heartbeat.py
+++ b/src/radical/utils/heartbeat.py
@@ -336,8 +336,9 @@ class PWatcher(object):
 
         self._send_signal(pid, signal.SIGTERM)
         self._send_signal(pid, signal.SIGKILL)
-      # self._send_signal(pid, signal.SIGKILL, group=True)
-      # self._send_signal(pid, signal.SIGKILL, group=True)
+        # NOTE: sending a signal to the process group causes pytest to fail
+        # self._send_signal(pid, signal.SIGKILL, group=True)
+        # self._send_signal(pid, signal.SIGKILL, group=True)
 
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
This PR is to discuss if (a) we need the PG kill as fallback, and if so, (b) how to ensure that pytest is not affected.