### PR TITLE
remove deepcopy, allow `as_dict` overwrite

### DIFF
--- a/src/radical/utils/logger.py
+++ b/src/radical/utils/logger.py
@@ -1,5 +1,4 @@
 
-
 __copyright__ = "Copyright 2013-2014, http://radical.rutgers.edu"
 __license__   = "MIT"
 

--- a/src/radical/utils/serialize.py
+++ b/src/radical/utils/serialize.py
@@ -50,7 +50,6 @@ class _json_encoder(json.JSONEncoder):
         return super().encode(tmp, *args, **kw)
 
     def default(self, o):
-        print('== encode: %s' % o)
         for cname,methods in _ctypes.items():
             if isinstance(o, methods.ctype):
                 return {'_type': cname,

--- a/src/radical/utils/serialize.py
+++ b/src/radical/utils/serialize.py
@@ -6,7 +6,7 @@ from .typeddict import as_dict, TypedDict
 
 # ------------------------------------------------------------------------------
 #
-class _CType:
+class _ClassType:
 
     def __init__(self, ctype, encode, decode):
 
@@ -33,15 +33,9 @@ def register_serializable(cls, encode=None, decode=None):
     if encode is None: encode = cls
     if decode is None: decode = cls
 
-    _ctypes[cls.__name__] = _CType(cls, encode, decode)
+    _ctypes[cls.__name__] = _ClassType(cls, encode, decode)
 
 register_serializable(TypedDict)
-
-
-# ------------------------------------------------------------------------------
-#
-def _prep_typed_dict(d):
-    return as_dict(d, _annotate=True)
 
 
 # ------------------------------------------------------------------------------
@@ -56,7 +50,7 @@ class _json_encoder(json.JSONEncoder):
         return super().encode(tmp, *args, **kw)
 
     def default(self, o):
-      # print('encode: %s' % o)
+        print('== encode: %s' % o)
         for cname,methods in _ctypes.items():
             if isinstance(o, methods.ctype):
                 return {'_type': cname,
@@ -70,16 +64,19 @@ def _json_decoder(obj):
     '''
     internal methods to decode registered classes from json
     '''
-  # print('decode: %s' % obj)
-    for cname, methods in _ctypes.items():
-      # print('check %s' % cname)
-        if '_type' in obj and obj['_type'] == cname:
-            del obj['_type']
-          # print('found %s' % cname)
-            if 'as_str' in obj:
-                return methods.decode(obj['as_str'])
-            return methods.decode(obj)
-    return obj
+    otype = obj.get('_type')
+    if not otype:
+        return obj
+
+    methods = _ctypes.get(otype)
+    if not methods:
+        return obj
+
+    del obj['_type']
+    if 'as_str' in obj:
+        return methods.decode(obj['as_str'])
+
+    return methods.decode(obj)
 
 
 # ------------------------------------------------------------------------------

--- a/src/radical/utils/typeddict.py
+++ b/src/radical/utils/typeddict.py
@@ -151,7 +151,7 @@ class TypedDict(dict, metaclass=TypedDictMeta):
 
         register_serializable(self.__class__)
 
-        self.update(self._defaults)
+        self.update(copy.deepcopy(self._defaults))
         self.update(from_dict)
 
         if kwargs:

--- a/src/radical/utils/typeddict.py
+++ b/src/radical/utils/typeddict.py
@@ -332,19 +332,13 @@ class TypedDict(dict, metaclass=TypedDictMeta):
         for k, v in self._data.items():
 
             if isinstance(v, TypedDict):
-                tgt[k] = v.as_dict()
+                tgt[k] = v.as_dict(_annotate=_annotate)
             else:
-                tgt[k] = as_dict(v)
+                tgt[k] = as_dict(v, _annotate=_annotate)
             if _annotate:
-                tgt['_type'] = type(src).__name__
+                tgt['_type'] = type(self).__name__
 
         return tgt
-
-
-    # --------------------------------------------------------------------------
-    #
-    def _as_dict(self, _annotate=False, _internal=False):
-        return as_dict(self._data, _annotate, _internal=_internal)
 
 
     # --------------------------------------------------------------------------
@@ -514,13 +508,13 @@ class TypedDict(dict, metaclass=TypedDictMeta):
 
 # ------------------------------------------------------------------------------
 #
-def as_dict(src, _annotate=False, _internal=False):
+def as_dict(src, _annotate=False):
     '''
     Iterate given object, apply `as_dict()` to all typed
     values, and return the result (effectively a shallow copy).
     '''
     if isinstance(src, TypedDict):
-        return src.as_dict()
+        return src.as_dict(_annotate=_annotate)
 
     if isinstance(src, dict):
         return {k: as_dict(v, _annotate) for k, v in src.items()}


### PR DESCRIPTION
This changes the semantics of `ru.TypedDict` to get back in sync with the default `dict` semantic, and specifically that non-trivial elements are stored by reference, not by value.  At the same time this improves performance by about 50%.

A second set of changes to the `as_dict` method now allows to overwrite that method for classes inheriting from `TypeDict`.